### PR TITLE
Only check spec-defined formats for strings

### DIFF
--- a/lib/json_schemer/format.rb
+++ b/lib/json_schemer/format.rb
@@ -66,7 +66,7 @@ module JSONSchemer
     IHIER_PART = Regexp.compile("(?:(?://#{IAUTHORITY}#{IPATH_ABEMPTY})|(?:#{IPATH_ABSOLUTE})|(?:#{IPATH_ROOTLESS})|(?:#{IPATH_EMPTY}))").freeze
     IRI = Regexp.compile("^#{SCHEME}:(?:#{IHIER_PART})(?:\\?#{IQUERY})?(?:\\##{IFRAGMENT})?$").freeze
 
-    def valid_format?(data, format)
+    def valid_spec_format?(data, format)
       case format
       when 'date-time'
         valid_date_time?(data)

--- a/lib/json_schemer/schema/draft4.rb
+++ b/lib/json_schemer/schema/draft4.rb
@@ -10,7 +10,8 @@ module JSONSchemer
         'hostname',
         'ipv4',
         'ipv6',
-        'uri'
+        'uri',
+        'regex'
       ].freeze
 
     private

--- a/lib/json_schemer/schema/draft6.rb
+++ b/lib/json_schemer/schema/draft6.rb
@@ -12,7 +12,8 @@ module JSONSchemer
         'uri',
         'uri-reference',
         'uri-template',
-        'json-pointer'
+        'json-pointer',
+        'regex'
       ].freeze
 
     private


### PR DESCRIPTION
https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-7.1

> A format attribute can generally only validate a given set
> of instance types. If the type of the instance to validate is not in
> this set, validation for this format attribute and instance SHOULD
> succeed.

This separates spec-defined formats from custom ones, because it's
unclear what instance types should be handled for custom formats.
Spec-defined formats only apply to strings, so I moved that check to
`validate_string`.

Closes #2.