### PR TITLE
Support ECMA 262 regular expression anchors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     json_schemer (0.1.6)
       ecma-re-validator (~> 0.1.2)
       hana (~> 1.3.3)
+      regexp_parser (~> 0.5.0)
       uri_template (~> 0.7.0)
 
 GEM

--- a/json_schemer.gemspec
+++ b/json_schemer.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "ecma-re-validator", "~> 0.1.2"
   spec.add_runtime_dependency "hana", "~> 1.3.3"
   spec.add_runtime_dependency "uri_template", "~> 0.7.0"
+  spec.add_runtime_dependency "regexp_parser", "~> 0.5.0"
 end

--- a/test/json_schemer_test.rb
+++ b/test/json_schemer_test.rb
@@ -424,6 +424,20 @@ class JSONSchemerTest < Minitest::Test
     assert counts['http://example.com/2'] == 1
   end
 
+  def test_it_handles_regex_anchors
+    schema = JSONSchemer.schema({ 'pattern' => '^foo$' })
+    assert schema.valid?('foo')
+    assert !schema.valid?(' foo')
+    assert !schema.valid?('foo ')
+    assert !schema.valid?("foo\nfoo\nfoo")
+
+    schema = JSONSchemer.schema({ 'pattern' => '\Afoo\z' })
+    assert schema.valid?('Afooz')
+    assert !schema.valid?('foo')
+    assert !schema.valid?('Afoo')
+    assert !schema.valid?('fooz')
+  end
+
   {
     'draft4' => JSONSchemer::Schema::Draft4,
     'draft6' => JSONSchemer::Schema::Draft6,


### PR DESCRIPTION
Ruby uses `^` in regular expressions to match the beginning of a line
(even in multiline strings) while in ECMA 262 it only matches the
beginning of the entire string. Same for `$` and the end of a line. This
parses the provided regular expressions and replaces the ECMA 262
anchors with their Ruby equivalents (`\A` and `\z`).

Fixes #11