### PR TITLE
update deprecations and dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,20 +2,20 @@ PATH
   remote: .
   specs:
     json_schemer (0.1.7)
-      ecma-re-validator (~> 0.1.2)
+      ecma-re-validator (~> 0.2.0)
       hana (~> 1.3.3)
-      regexp_parser (~> 0.5.0)
+      regexp_parser (~> 1.2.0)
       uri_template (~> 0.7.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    ecma-re-validator (0.1.2)
-      regexp_parser (~> 0.2)
+    ecma-re-validator (0.2.0)
+      regexp_parser (~> 1.2)
     hana (1.3.4)
     minitest (5.11.1)
     rake (10.5.0)
-    regexp_parser (0.5.0)
+    regexp_parser (1.2.0)
     uri_template (0.7.0)
 
 PLATFORMS

--- a/json_schemer.gemspec
+++ b/json_schemer.gemspec
@@ -31,8 +31,8 @@ Gem::Specification.new do |spec|
   # spec.add_development_dependency "json_validation", "~> 0.1.0"
   # spec.add_development_dependency "jsonschema", "~> 2.0.2"
 
-  spec.add_runtime_dependency "ecma-re-validator", "~> 0.1.2"
+  spec.add_runtime_dependency "ecma-re-validator", "~> 0.2.0"
   spec.add_runtime_dependency "hana", "~> 1.3.3"
   spec.add_runtime_dependency "uri_template", "~> 0.7.0"
-  spec.add_runtime_dependency "regexp_parser", "~> 0.5.0"
+  spec.add_runtime_dependency "regexp_parser", "~> 1.2.0"
 end

--- a/lib/json_schemer/schema/base.rb
+++ b/lib/json_schemer/schema/base.rb
@@ -228,7 +228,7 @@ module JSONSchemer
         ref_uri = join_uri(instance.parent_uri, ref)
 
         if valid_json_pointer?(ref_uri.fragment)
-          ref_pointer = Hana::Pointer.new(URI.unescape(ref_uri.fragment))
+          ref_pointer = Hana::Pointer.new(URI.decode_www_form_component(ref_uri.fragment))
           if ref.start_with?('#')
             subinstance = instance.merge(
               schema: ref_pointer.eval(root),

--- a/test/json_schemer_test.rb
+++ b/test/json_schemer_test.rb
@@ -1,5 +1,6 @@
 require 'test_helper'
 require 'json'
+require 'pathname'
 
 class JSONSchemerTest < Minitest::Test
   def test_that_it_has_a_version_number


### PR DESCRIPTION
Capybara requires a newer version of regexp_parser so I updated your dependency, ecma-re-validator.
Now to update json_schemer
Thanks for the sweet gem!
Plated will be using it to validate our messages we send to SNS to make sure we aren't missing any data