### PR TITLE
require 'pathname' for Pathname

### DIFF
--- a/lib/json_schemer.rb
+++ b/lib/json_schemer.rb
@@ -7,6 +7,7 @@ require 'json_schemer/schema/base'
 require 'json_schemer/schema/draft4'
 require 'json_schemer/schema/draft6'
 require 'json_schemer/schema/draft7'
+require 'pathname'
 
 module JSONSchemer
   class UnsupportedMetaSchema < StandardError; end


### PR DESCRIPTION
without this change, this fails:

```console
$ ruby -r json_schemer -e 'JSONSchemer.schema({"type"=>"object"})'
Traceback (most recent call last):
        1: from -e:1:in `<main>'
/home/martin/.gem/ruby/2.5.0/gems/json_schemer-0.1.8/lib/json_schemer.rb:36:in `schema': uninitialized constant #<Class:JSONSchemer>::Pathname (NameError)
```