### PR TITLE
add rj_schema to benchmark

### DIFF
--- a/json_schemer.gemspec
+++ b/json_schemer.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   # spec.add_development_dependency "json_schema", "~> 0.17.0"
   # spec.add_development_dependency "json_validation", "~> 0.1.0"
   # spec.add_development_dependency "jsonschema", "~> 2.0.2"
+  # spec.add_development_dependency "rj_schema", "~> 0.2.0"
 
   spec.add_runtime_dependency "ecma-re-validator", "~> 0.2.0"
   spec.add_runtime_dependency "hana", "~> 1.3.3"

--- a/test/benchmark.rb
+++ b/test/benchmark.rb
@@ -8,6 +8,7 @@ require 'json-schema'
 require 'json_schema'
 require 'json_schemer'
 require 'json_validation'
+require 'rj_schema'
 # require 'jsonschema'
 
 # json_validation
@@ -54,6 +55,7 @@ Benchmark.ips do |x|
     initialized_json_schema = JsonSchema.parse!(schema).tap(&:expand_references!)
     initialized_json_schemer = JSONSchemer.schema(schema)
     initialized_json_validation = JsonValidation.build_validator(schema)
+    initialized_rj_schema = RjSchema::Validator.new('schema' => schema)
 
     # jschema
 
@@ -94,7 +96,7 @@ Benchmark.ips do |x|
       raise if !success || errors.any?
     end
 
-    x.report("json_schem, uninitialized, #{name}, invalid") do
+    x.report("json_schema, uninitialized, #{name}, invalid") do
       success, errors = JsonSchema.parse!(schema).tap(&:expand_references!).validate(invalid)
       raise if success || errors.empty?
     end
@@ -104,7 +106,7 @@ Benchmark.ips do |x|
       raise if !success || errors.any?
     end
 
-    x.report("json_schem, initialized, #{name}, invalid") do
+    x.report("json_schema, initialized, #{name}, invalid") do
       success, errors = initialized_json_schema.validate(invalid)
       raise if success || errors.empty?
     end
@@ -147,6 +149,28 @@ Benchmark.ips do |x|
 
     x.report("json_validation, initialized, #{name}, invalid") do
       raise if initialized_json_validation.validate(invalid)
+    end
+
+    # rj_schema
+
+    x.report("rj_schema, uninitialized, #{name}, valid") do
+      errors = RjSchema::Validator.new.validate(schema, valid)
+      raise if errors.any?
+    end
+
+    x.report("rj_schema, uninitialized, #{name}, invalid") do
+      errors = RjSchema::Validator.new.validate(schema, invalid)
+      raise if errors.empty?
+    end
+
+    x.report("rj_schema, initialized, #{name}, valid") do
+      errors = initialized_rj_schema.validate(:"schema", valid)
+      raise if errors.any?
+    end
+
+    x.report("rj_schema, initialized, #{name}, invalid") do
+      errors = initialized_rj_schema.validate(:"schema", invalid)
+      raise if errors.empty?
     end
 
     # jsonschema


### PR DESCRIPTION
Hello!

This morning I added https://github.com/foxtacles/rj_schema to the benchmark since I was interested how it would compare. I believe it's the only JSON schema validation gem right now that uses native code for extra performance, so I think it's an interesting comparison. Feel free to reject this PR though, just felt like sharing.

It would probably be a good idea to create a benchmark that is based on more than just a single schema to get a proper comparison, however? I used the JSON schema test suite before for this purpose.

Here are the results I collected for anyone who's curious:

```
Comparison:
json_validation, initialized, simple, invalid:   211258.0 i/s
jschema, initialized, simple, valid:   183982.2 i/s - 1.15x  slower
rj_schema, initialized, simple, valid:   170152.3 i/s - 1.24x  slower
json_validation, initialized, simple, valid:   132849.3 i/s - 1.59x  slower
jschema, initialized, simple, invalid:   103665.6 i/s - 2.04x  slower
json_schemer, initialized, simple, invalid:    76856.8 i/s - 2.75x  slower
json_schemer, initialized, simple, valid:    70213.8 i/s - 3.01x  slower
json_schema, initialized, simple, valid:    67855.5 i/s - 3.11x  slower
rj_schema, initialized, simple, invalid:    66942.8 i/s - 3.16x  slower
json_schemer, uninitialized, simple, invalid:    66415.8 i/s - 3.18x  slower
json_schemer, uninitialized, simple, valid:    59902.8 i/s - 3.53x  slower
json_schema, initialized, simple, invalid:    50348.6 i/s - 4.20x  slower
rj_schema, uninitialized, simple, valid:    38883.8 i/s - 5.43x  slower
rj_schema, uninitialized, simple, invalid:    28282.0 i/s - 7.47x  slower
json_validation, uninitialized, simple, invalid:    20527.6 i/s - 10.29x  slower
json_validation, uninitialized, simple, valid:    19048.6 i/s - 11.09x  slower
jschema, uninitialized, simple, valid:     5338.4 i/s - 39.57x  slower
json-schema, simple, valid:     5335.3 i/s - 39.60x  slower
jschema, uninitialized, simple, invalid:     5125.4 i/s - 41.22x  slower
json-schema, simple, invalid:     4884.0 i/s - 43.26x  slower
json_schema, uninitialized, simple, valid:     1811.1 i/s - 116.65x  slower
json_schema, uninitialized, simple, invalid:     1799.7 i/s - 117.38x  slower
```