### PR TITLE
Add missing keys details on required validation errors

### DIFF
--- a/lib/json_schemer/schema/base.rb
+++ b/lib/json_schemer/schema/base.rb
@@ -179,8 +179,8 @@ module JSONSchemer
         )
       end
 
-      def error(instance, type)
-        {
+      def error(instance, type, details = nil)
+        error = {
           'data' => instance.data,
           'data_pointer' => instance.data_pointer,
           'schema' => instance.schema,
@@ -188,6 +188,8 @@ module JSONSchemer
           'root_schema' => root,
           'type' => type,
         }
+        error['details'] = details if details
+        error
       end
 
       def validate_class(instance)
@@ -453,7 +455,10 @@ module JSONSchemer
 
         yield error(instance, 'maxProperties') if max_properties && data.size > max_properties
         yield error(instance, 'minProperties') if min_properties && data.size < min_properties
-        yield error(instance, 'required') if required && required.any? { |key| !data.key?(key) }
+        if required
+          missing_keys = required - data.keys
+          yield error(instance, 'required', 'missing_keys' => missing_keys) if missing_keys.any?
+        end
 
         regex_pattern_properties = nil
         data.each do |key, value|

--- a/test/json_schemer_test.rb
+++ b/test/json_schemer_test.rb
@@ -372,6 +372,13 @@ class JSONSchemerTest < Minitest::Test
     assert schema.valid?({ 'id' => 1, 'a' => 'abc' })
   end
 
+  def test_required_validation_adds_missing_keys
+    schema = JSONSchemer.schema(Pathname.new(__dir__).join('schemas', 'schema1.json'))
+    error = schema.validate({ 'id' => 1 }).first
+    assert error.fetch('type') == 'required'
+    assert error.fetch('details') == { 'missing_keys' => ['a'] }
+  end
+
   def test_it_allows_custom_ref_resolver_with_pathnames
     count = 0
     schema = JSONSchemer.schema(


### PR DESCRIPTION
As discussed in #24 this small change will make `required` validation errors a lot more readable.

This could be expanded for every other error that would benefit from adding specific details.