### PR TITLE
Remove regexp_parser dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,6 @@ PATH
     json_schemer (0.2.1)
       ecma-re-validator (~> 0.2.0)
       hana (~> 1.3.3)
-      regexp_parser (~> 1.5.0)
       uri_template (~> 0.7.0)
 
 GEM

--- a/json_schemer.gemspec
+++ b/json_schemer.gemspec
@@ -35,5 +35,4 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "ecma-re-validator", "~> 0.2.0"
   spec.add_runtime_dependency "hana", "~> 1.3.3"
   spec.add_runtime_dependency "uri_template", "~> 0.7.0"
-  spec.add_runtime_dependency "regexp_parser", "~> 1.5.0"
 end


### PR DESCRIPTION
json_schemer doesn't seem to directly require or depende on regexp_parser. It requires ecma-re-validator, which uses regexp_parser vicariously. So we should only require on ecma-re-validator, and allow it to require on its upstream dependencies correctly.

(The current dependency is too strict and is preventing us from using regexp_parser 1.6.0 via other gems.)