### PR TITLE
Use `ref_uri` as parent if id is not found

### DIFF
--- a/lib/json_schemer/schema/base.rb
+++ b/lib/json_schemer/schema/base.rb
@@ -258,7 +258,7 @@ module JSONSchemer
             subinstance = instance.merge(
               schema: ref_pointer.eval(root),
               schema_pointer: ref_uri.fragment,
-              parent_uri: pointer_uri(root, ref_pointer)
+              parent_uri: (pointer_uri(root, ref_pointer) || ref_uri)
             )
             validate_instance(subinstance, &block)
           else
@@ -267,7 +267,7 @@ module JSONSchemer
             subinstance = instance.merge(
               schema: ref_pointer.eval(ref_root),
               schema_pointer: ref_uri.fragment,
-              parent_uri: pointer_uri(ref_root, ref_pointer)
+              parent_uri: (pointer_uri(ref_root, ref_pointer) || ref_uri)
             )
             ref_object.validate_instance(subinstance, &block)
           end

--- a/test/json_schemer_test.rb
+++ b/test/json_schemer_test.rb
@@ -646,6 +646,12 @@ class JSONSchemerTest < Minitest::Test
     }
   end
 
+  def test_it_handles_nested_refs
+    schema = JSONSchemer.schema(Pathname.new(__dir__).join('schemas', 'nested_ref1.json'))
+    assert schema.valid?(1)
+    refute schema.valid?('1')
+  end
+
   def test_json_schema_test_suite
     {
       'draft4' => JSONSchemer::Schema::Draft4,

--- a/test/schemas/nested_ref1.json
+++ b/test/schemas/nested_ref1.json
@@ -1,0 +1,3 @@
+{
+  "$ref": "nested_ref2.json"
+}

--- a/test/schemas/nested_ref2.json
+++ b/test/schemas/nested_ref2.json
@@ -1,0 +1,12 @@
+{
+  "definitions": {
+    "nested": {
+      "$ref": "nested_ref3.json"
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "#/definitions/nested"
+    }
+  ]
+}

--- a/test/schemas/nested_ref3.json
+++ b/test/schemas/nested_ref3.json
@@ -1,0 +1,3 @@
+{
+  "type": "number"
+}


### PR DESCRIPTION
This allows `parent_uri` to be maintained when using relative refs
across multiple files. Previously, `nested_ref2.json` was causing issues
because the internal ref (`#/definitions/nested`) reset `parent_uri` to
nil.

Fixes: https://github.com/davishmcclurg/json_schemer/issues/43