### PR TITLE
Switch to stdlib URI for URI/IRI validation

### DIFF
--- a/lib/json_schemer/format.rb
+++ b/lib/json_schemer/format.rb
@@ -9,56 +9,7 @@ module JSONSchemer
     JSON_POINTER_REGEX = /\A#{JSON_POINTER_REGEX_STRING}\z/.freeze
     RELATIVE_JSON_POINTER_REGEX = /\A(0|[1-9]\d*)(#|#{JSON_POINTER_REGEX_STRING})?\z/.freeze
     DATE_TIME_OFFSET_REGEX = /(Z|[\+\-]([01][0-9]|2[0-3]):[0-5][0-9])\z/i.freeze
-
-    # https://github.com/ruby-rdf/rdf
-
-    # IRI components
-    UCSCHAR = Regexp.compile(<<-EOS.gsub(/\s+/, ''))
-      [\\u00A0-\\uD7FF]|[\\uF900-\\uFDCF]|[\\uFDF0-\\uFFEF]|
-      [\\u{10000}-\\u{1FFFD}]|[\\u{20000}-\\u{2FFFD}]|[\\u{30000}-\\u{3FFFD}]|
-      [\\u{40000}-\\u{4FFFD}]|[\\u{50000}-\\u{5FFFD}]|[\\u{60000}-\\u{6FFFD}]|
-      [\\u{70000}-\\u{7FFFD}]|[\\u{80000}-\\u{8FFFD}]|[\\u{90000}-\\u{9FFFD}]|
-      [\\u{A0000}-\\u{AFFFD}]|[\\u{B0000}-\\u{BFFFD}]|[\\u{C0000}-\\u{CFFFD}]|
-      [\\u{D0000}-\\u{DFFFD}]|[\\u{E1000}-\\u{EFFFD}]
-    EOS
-    IPRIVATE = Regexp.compile("[\\uE000-\\uF8FF]|[\\u{F0000}-\\u{FFFFD}]|[\\u100000-\\u10FFFD]").freeze
-    SCHEME = Regexp.compile("[A-Za-z](?:[A-Za-z0-9+-\.])*").freeze
-    PORT = Regexp.compile("[0-9]*").freeze
-    IP_LITERAL = Regexp.compile("\\[[0-9A-Fa-f:\\.]*\\]").freeze  # Simplified, no IPvFuture
-    PCT_ENCODED = Regexp.compile("%[0-9A-Fa-f][0-9A-Fa-f]").freeze
-    GEN_DELIMS = Regexp.compile("[:/\\?\\#\\[\\]@]").freeze
-    SUB_DELIMS = Regexp.compile("[!\\$&'\\(\\)\\*\\+,;=]").freeze
-    RESERVED = Regexp.compile("(?:#{GEN_DELIMS}|#{SUB_DELIMS})").freeze
-    UNRESERVED = Regexp.compile("[A-Za-z0-9\._~-]").freeze
-
-    IUNRESERVED = Regexp.compile("[A-Za-z0-9\._~-]|#{UCSCHAR}").freeze
-
-    IPCHAR = Regexp.compile("(?:#{IUNRESERVED}|#{PCT_ENCODED}|#{SUB_DELIMS}|:|@)").freeze
-
-    IQUERY = Regexp.compile("(?:#{IPCHAR}|#{IPRIVATE}|/|\\?)*").freeze
-
-    IFRAGMENT = Regexp.compile("(?:#{IPCHAR}|/|\\?)*").freeze.freeze
-
-    ISEGMENT = Regexp.compile("(?:#{IPCHAR})*").freeze
-    ISEGMENT_NZ = Regexp.compile("(?:#{IPCHAR})+").freeze
-    ISEGMENT_NZ_NC = Regexp.compile("(?:(?:#{IUNRESERVED})|(?:#{PCT_ENCODED})|(?:#{SUB_DELIMS})|@)+").freeze
-
-    IPATH_ABEMPTY = Regexp.compile("(?:/#{ISEGMENT})*").freeze
-    IPATH_ABSOLUTE = Regexp.compile("/(?:(?:#{ISEGMENT_NZ})(/#{ISEGMENT})*)?").freeze
-    IPATH_NOSCHEME = Regexp.compile("(?:#{ISEGMENT_NZ_NC})(?:/#{ISEGMENT})*").freeze
-    IPATH_ROOTLESS = Regexp.compile("(?:#{ISEGMENT_NZ})(?:/#{ISEGMENT})*").freeze
-    IPATH_EMPTY = Regexp.compile("").freeze
-
-    IREG_NAME   = Regexp.compile("(?:(?:#{IUNRESERVED})|(?:#{PCT_ENCODED})|(?:#{SUB_DELIMS}))*").freeze
-    IHOST = Regexp.compile("(?:#{IP_LITERAL})|(?:#{IREG_NAME})").freeze
-    IUSERINFO = Regexp.compile("(?:(?:#{IUNRESERVED})|(?:#{PCT_ENCODED})|(?:#{SUB_DELIMS})|:)*").freeze
-    IAUTHORITY = Regexp.compile("(?:#{IUSERINFO}@)?#{IHOST}(?::#{PORT})?").freeze
-
-    IRELATIVE_PART = Regexp.compile("(?:(?://#{IAUTHORITY}(?:#{IPATH_ABEMPTY}))|(?:#{IPATH_ABSOLUTE})|(?:#{IPATH_NOSCHEME})|(?:#{IPATH_EMPTY}))").freeze
-    IRELATIVE_REF = Regexp.compile("^#{IRELATIVE_PART}(?:\\?#{IQUERY})?(?:\\##{IFRAGMENT})?$").freeze
-
-    IHIER_PART = Regexp.compile("(?:(?://#{IAUTHORITY}#{IPATH_ABEMPTY})|(?:#{IPATH_ABSOLUTE})|(?:#{IPATH_ROOTLESS})|(?:#{IPATH_EMPTY}))").freeze
-    IRI = Regexp.compile("^#{SCHEME}:(?:#{IHIER_PART})(?:\\?#{IQUERY})?(?:\\##{IFRAGMENT})?$").freeze
+    INVALID_QUERY_REGEX = /[[:space:]]/.freeze
 
     def valid_spec_format?(data, format)
       case format
@@ -81,13 +32,13 @@ module JSONSchemer
       when 'ipv6'
         valid_ip?(data, :v6)
       when 'uri'
-        data.ascii_only? && valid_iri?(data)
+        valid_uri?(data)
       when 'uri-reference'
-        data.ascii_only? && (valid_iri?(data) || valid_iri_reference?(data))
+        valid_uri_reference?(data)
       when 'iri'
-        valid_iri?(data)
+        valid_uri?(iri_escape(data))
       when 'iri-reference'
-        valid_iri?(data) || valid_iri_reference?(data)
+        valid_uri_reference?(iri_escape(data))
       when 'uri-template'
         valid_uri_template?(data)
       when 'json-pointer'
@@ -129,12 +80,28 @@ module JSONSchemer
       false
     end
 
-    def valid_iri?(data)
-      IRI.match?(data)
+    def parse_uri_scheme(data)
+      scheme, _userinfo, _host, _port, _registry, _path, opaque, query, _fragment = URI::RFC3986_PARSER.split(data)
+      # URI::RFC3986_PARSER.parse allows spaces in these and I don't think it should
+      raise URI::InvalidURIError if INVALID_QUERY_REGEX.match?(query) || INVALID_QUERY_REGEX.match?(opaque)
+      scheme
     end
 
-    def valid_iri_reference?(data)
-      IRELATIVE_REF.match?(data)
+    def valid_uri?(data)
+      !!parse_uri_scheme(data)
+    rescue URI::InvalidURIError
+      false
+    end
+
+    def valid_uri_reference?(data)
+      parse_uri_scheme(data)
+      true
+    rescue URI::InvalidURIError
+      false
+    end
+
+    def iri_escape(data)
+      URI.escape(data, /[^[[:ascii:]]]/)
     end
 
     def valid_uri_template?(data)


### PR DESCRIPTION
Ruby's URI regular expressions are probably better than the ones I
pulled from rdf. The slow input from #46 is parsed much faster:

```
> puts Benchmark.measure { valid_uri?('http://example.com/?zzzzzzzzzzzzzzzzzzzzzzzzz=uhoh ') }
  0.000036   0.000002   0.000038 (  0.000034)
```

I added an additional check for whitespace in queries, because
`URI.parse` allows it for some reason.

I'm not sure about `iri_escape` but I believe it works because it's only
escaping non-ascii characters.

Fixes: #46