### PR TITLE
Stop treating JSON pointer refs as URIs

### DIFF
--- a/test/json_schemer_test.rb
+++ b/test/json_schemer_test.rb
@@ -652,6 +652,16 @@ class JSONSchemerTest < Minitest::Test
     refute schema.valid?('1')
   end
 
+  def test_it_handles_json_pointer_refs_with_special_characters
+    schema = JSONSchemer.schema({
+      'type' => 'object',
+      'properties' => { 'foo' => { '$ref' => '#/definitions/~1some~1{id}'} },
+      'definitions' => { '/some/{id}' => { 'type' => 'string' } }
+    })
+    assert schema.valid?({ 'foo' => 'bar' })
+    refute schema.valid?({ 'foo' => 1 })
+  end
+
   def test_json_schema_test_suite
     {
       'draft4' => JSONSchemer::Schema::Draft4,


### PR DESCRIPTION
JSON pointer refs don't need to be encoded the same way as URIs.

Values with some special characters were causing issues:

```
% ruby -e "URI.parse('#/definitions/~1some~1{id}')"
Traceback (most recent call last):
	3: from -e:1:in `<main>'
	2: from /Users/dharsha/.rbenv/versions/2.5.1/lib/ruby/2.5.0/uri/common.rb:237:in `parse'
	1: from /Users/dharsha/.rbenv/versions/2.5.1/lib/ruby/2.5.0/uri/rfc3986_parser.rb:73:in `parse'
/Users/dharsha/.rbenv/versions/2.5.1/lib/ruby/2.5.0/uri/rfc3986_parser.rb:67:in `split': bad URI(is not URI?): #/definitions/~1some~1{id} (URI::InvalidURIError)
```

Fixes: #54