### PR TITLE
Format pretty messages from error hash

### DIFF
--- a/lib/json_schemer.rb
+++ b/lib/json_schemer.rb
@@ -14,6 +14,7 @@ require 'uri_template'
 
 require 'json_schemer/version'
 require 'json_schemer/format'
+require 'json_schemer/errors'
 require 'json_schemer/cached_ref_resolver'
 require 'json_schemer/schema/base'
 require 'json_schemer/schema/draft4'

--- a/lib/json_schemer/errors.rb
+++ b/lib/json_schemer/errors.rb
@@ -26,6 +26,9 @@ module JSONSchemer
       when 'format'
         format = error['schema']['format']
         "property '#{data_path}' does not match format: #{format}"
+      when 'const'
+        value = error['schema']['const'].dump
+        "property '#{data_path}' is not: #{value}"
       when 'enum'
         options = error['schema']['enum']
         "property '#{data_path}' is not one of enum: #{options}"

--- a/lib/json_schemer/errors.rb
+++ b/lib/json_schemer/errors.rb
@@ -1,0 +1,45 @@
+# Based on code from @robacarp found in issue 48:
+# https://github.com/davishmcclurg/json_schemer/issues/48
+#
+module JSONSchemer
+  module Errors
+    module_function
+
+    def pretty(error)
+      data_path = format_data_pointer error['data_pointer']
+
+      case error['type']
+      when 'required'
+        keys = error['details']['missing_keys'].join(', ')
+        "#{data_path} is missing required keys: #{keys}"
+      when 'null',
+           'string',
+           'boolean',
+           'integer',
+           'number',
+           'array',
+           'object'
+        "property '#{data_path}' should be of type: #{error['type']}"
+      when 'pattern'
+        pattern = error['schema']['pattern']
+        "property '#{data_path}' does not match pattern: #{pattern}"
+      when 'format'
+        format = error['schema']['format']
+        "property '#{data_path}' does not match format: #{format}"
+      when 'enum'
+        options = error['schema']['enum']
+        "property '#{data_path}' is not one of enum: #{options}"
+      else
+        "does not validate: error_type=#{error['type']}"
+      end
+    end
+
+    def format_data_pointer(data_pointer)
+      return 'root' if data_pointer.nil? || data_pointer.empty?
+
+      data_pointer
+        .sub(%r{^/}, '')   # remove leading /
+        .sub('/', '.')     # convert / into .
+    end
+  end
+end

--- a/test/pretty_errors_test.rb
+++ b/test/pretty_errors_test.rb
@@ -90,4 +90,20 @@ class PrettyErrorsTest < Minitest::Test
     assert JSONSchemer::Errors.pretty(error) ==
            "property 'one' is not one of enum: [\"one\", \"two\"]"
   end
+
+  def test_const_message
+    schema = JSONSchemer.schema(
+      {
+        'properties' => {
+          'one' => {
+            'type' => 'string',
+            'const' => 'one'
+          }
+        }
+      }
+    )
+    error = schema.validate({ 'one' => 'abc' }).to_a.first
+    assert JSONSchemer::Errors.pretty(error) ==
+           "property 'one' is not: \"one\""
+  end
 end

--- a/test/pretty_errors_test.rb
+++ b/test/pretty_errors_test.rb
@@ -1,0 +1,93 @@
+require 'test_helper'
+
+class PrettyErrorsTest < Minitest::Test
+  def test_required_message
+    schema = JSONSchemer.schema(
+      {
+        'properties' => {
+          'one' => { 'type' => 'string' }
+        },
+        'required' => %w[one]
+      }
+    )
+    error = schema.validate({ 'two' => 'optional' }).to_a.first
+    assert JSONSchemer::Errors.pretty(error) ==
+           'root is missing required keys: one'
+  end
+
+  def test_basic_type_message
+    %w[string integer number boolean null object].each do |type|
+      schema = JSONSchemer.schema(
+        {
+          'properties' => {
+            'one' => { 'type' => type }
+          }
+        }
+      )
+      error = schema.validate({ 'one' => ['wrong'] }).to_a.first
+      assert JSONSchemer::Errors.pretty(error) ==
+             "property 'one' should be of type: #{type}"
+    end
+  end
+
+  def test_array_message
+    schema = JSONSchemer.schema(
+      {
+        'properties' => {
+          'one' => { 'type' => 'array' }
+        }
+      }
+    )
+    error = schema.validate({ 'one' => 'wrong' }).to_a.first
+    assert JSONSchemer::Errors.pretty(error) ==
+           "property 'one' should be of type: array"
+  end
+
+  def test_format_message
+    schema = JSONSchemer.schema(
+      {
+        'properties' => {
+          'one' => {
+            'type' => 'string',
+            'format' => 'date-time'
+          }
+        }
+      }
+    )
+    error = schema.validate({ 'one' => 'abc' }).to_a.first
+    assert JSONSchemer::Errors.pretty(error) ==
+           "property 'one' does not match format: date-time"
+  end
+
+  def test_pattern_message
+    schema = JSONSchemer.schema(
+      {
+        'properties' => {
+          'one' => {
+            'type' => 'string',
+            'pattern' => '\d+'
+          }
+        }
+      }
+    )
+    error = schema.validate({ 'one' => 'abc' }).to_a.first
+    assert JSONSchemer::Errors.pretty(error) ==
+           "property 'one' does not match pattern: \\d+"
+  end
+
+  def test_enum_message
+    schema = JSONSchemer.schema(
+      {
+        'properties' => {
+          'one' => {
+            'type' => 'string',
+            'enum' => %w[one two]
+          }
+        }
+      }
+    )
+    error = schema.validate({ 'one' => 'abc' }).to_a.first
+    assert JSONSchemer::Errors.pretty(error) ==
+           "property 'one' is not one of enum: [\"one\", \"two\"]"
+  end
+end


### PR DESCRIPTION
This is based on a snippet of code offered by @robacarp in #48. The code has
been cleaned up and tested and provides a standalone interface for converting
errors into a human readable message:

```ruby
errors = schema.validate({ 'a' => { 'x' => 1 } }).to_a
errors.map {|err| JSONSchemer::Errors.pretty err }
```

Longer term, an option can be introduced that allows the generation of the
message inline with the validation. For example, given the option `pretty:
true`, then on line 229 of `lib/json_schemer/schema/base.rb` (as of #a2a6df8),
the message could be added to the error hash:

```ruby
  error['message'] = JSONSchemer::Errors.pretty(error) if pretty
```