### PR TITLE
Resolve nested subschemas from id refs 

### DIFF
--- a/lib/json_schemer/schema/base.rb
+++ b/lib/json_schemer/schema/base.rb
@@ -617,13 +617,11 @@ module JSONSchemer
         elsif schema.is_a?(Hash)
           uri = join_uri(parent_uri, schema[id_keyword])
           schema.each do |key, value| 
-            if key == id_keyword
-              unless uri == parent_uri
+            if key == id_keyword &&  uri != parent_uri
                 ids[uri.to_s] = {
                   schema: schema,
                   pointer: pointer
                 }
-              end
             end
             resolve_ids(value, ids, uri, "#{pointer}/#{key}") 
           end

--- a/lib/json_schemer/schema/base.rb
+++ b/lib/json_schemer/schema/base.rb
@@ -618,10 +618,10 @@ module JSONSchemer
           uri = join_uri(parent_uri, schema[id_keyword])
           schema.each do |key, value| 
             if key == id_keyword &&  uri != parent_uri
-                ids[uri.to_s] = {
-                  schema: schema,
-                  pointer: pointer
-                }
+              ids[uri.to_s] = {
+                schema: schema,
+                pointer: pointer
+              }
             end
             resolve_ids(value, ids, uri, "#{pointer}/#{key}") 
           end

--- a/lib/json_schemer/schema/base.rb
+++ b/lib/json_schemer/schema/base.rb
@@ -615,16 +615,17 @@ module JSONSchemer
         if schema.is_a?(Array)
           schema.each_with_index { |subschema, index| resolve_ids(subschema, ids, parent_uri, "#{pointer}/#{index}") }
         elsif schema.is_a?(Hash)
-          id = schema[id_keyword]
-          uri = join_uri(parent_uri, id)
-          unless uri == parent_uri
-            ids[uri.to_s] = {
-              schema: schema,
-              pointer: pointer
-            }
-          end
-          if definitions = schema['definitions']
-            definitions.each { |key, subschema| resolve_ids(subschema, ids, uri, "#{pointer}/definitions/#{key}") }
+          uri = join_uri(parent_uri, schema[id_keyword])
+          schema.each do |key, value| 
+            if key == id_keyword
+              unless uri == parent_uri
+                ids[uri.to_s] = {
+                  schema: schema,
+                  pointer: pointer
+                }
+              end
+            end
+            resolve_ids(value, ids, uri, "#{pointer}/#{key}") 
           end
         end
         ids

--- a/test/json_schemer_test.rb
+++ b/test/json_schemer_test.rb
@@ -354,6 +354,133 @@ class JSONSchemerTest < Minitest::Test
     }
   end
 
+  def test_can_refer_to_subschemas_inside_hashes
+    root = {
+     'foo' => {
+        'bar' => {
+          '$id' => '#bar',
+          'type' => 'string'
+        }
+      },
+      '$ref' => '#bar'
+    }
+    schema = JSONSchemer.schema(
+      root
+    )
+    errors = schema.validate(42).to_a
+    assert errors.first == {
+      'data' => 42,
+      'data_pointer' => '',
+      'schema' => root['foo']['bar'],
+      'schema_pointer' => '/foo/bar',
+      'root_schema' => root,
+      'type' => 'string'
+    }
+  end
+
+  def test_can_refer_to_subschemas_inside_arrays
+    root = {
+     'foo' => [{
+        'bar' => {
+          '$id' => '#bar',
+          'type' => 'string'
+        }
+      }],
+      'properties' => {
+        'a' => {
+          'properties' => {
+            'x' => { '$ref' => '#bar' }
+          }
+        }
+      }
+    }
+    schema = JSONSchemer.schema(root)
+    errors = schema.validate({ 'a' => { 'x' => 1 } }).to_a
+    assert errors.first == {
+      'data' => 1,
+      'data_pointer' => '/a/x',
+      'schema' => root['foo'].first['bar'],
+      'schema_pointer' => '/foo/0/bar',
+      'root_schema' => root,
+      'type' => 'string'
+    }
+  end
+
+  def test_can_refer_to_subschemas_in_hash_with_remote_pointer
+    ref_schema = {
+      '$id' => 'http://example.com/ref_schema.json',
+      'foo' => {
+        'bar' => {
+          '$id' => '#bar',
+          'type' => 'string'
+        }
+      }
+    }
+    root = {
+      'properties' => {
+        'a' => {
+          'properties' => {
+            'x' => { '$ref' => 'http://example.com/ref_schema.json#bar' }
+          }
+        }
+      }
+    }
+    schema = JSONSchemer.schema(
+      root,
+      ref_resolver: proc { ref_schema }
+    )
+    errors = schema.validate({ 'a' => { 'x' => 1 } }).to_a
+    assert errors.first == {
+      'data' => 1,
+      'data_pointer' => '/a/x',
+      'schema' => ref_schema['foo']['bar'],
+      'schema_pointer' => '/foo/bar',
+      'root_schema' => ref_schema,
+      'type' => 'string'
+    }
+  end
+
+  def test_can_refer_to_multiple_subschemas_in_hash
+    ref_schema = {
+      '$id' => 'http://example.com/ref_schema.json',
+      'types' => {
+        'uuid' => {
+           '$id' => "#uuid",
+           'type' => 'string',
+           'pattern' => "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+        }
+      },
+      'foo' => {
+        'bar' => {
+          '$id' => '#bar',
+          'allOf' => [{ "$ref" => "#uuid"}]
+        }
+      }
+    }
+    root = {
+      'properties' => {
+        'a' => {
+          'properties' => {
+            'x' => { '$ref' => 'http://example.com/ref_schema.json#bar' }
+          }
+        }
+      }
+    }
+    schema = JSONSchemer.schema(
+      root,
+      ref_resolver: proc { ref_schema }
+    )
+    errors = schema.validate({ 'a' => { 'x' => "1122-112" } }).to_a
+    assert errors.first == {
+      'data' => "1122-112",
+      'data_pointer' => '/a/x',
+      'schema' => ref_schema['types']['uuid'],
+      'schema_pointer' => '/types/uuid',
+      'root_schema' => ref_schema,
+      'type' => 'pattern'
+    }
+  end
+
   def test_it_returns_correct_pointers_for_remote_ref_id
     ref_schema = {
       '$id' => 'http://example.com/remote-id',


### PR DESCRIPTION
 https://json-schema.org/understanding-json-schema/structuring.html#using-id-with-ref

This PR allows id refs to work in nested json structures, as outlined in the spec by building relative json pointers for every ID found in the document. @eraserhd

Fixes #69 