### PR TITLE
Add before_validation,after_validation options to hook into the validation process

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ JSONSchemer.schema(
   # Proc/[Proc]
   # default: nil
   after_property_validation: proc do |data, property, property_schema, _parent|
-    data[property] = Date.iso8601(data[property]) if && property_schema.is_a?(Hash) && property_schema['format'] == 'date'
+    data[property] = Date.iso8601(data[property]) if property_schema.is_a?(Hash) && property_schema['format'] == 'date'
   end,
 
   # resolve external references

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ JSONSchemer.schema(
   # Proc/[Proc]
   # default: nil
   after_property_validation: proc do |data, property, property_schema|
-    data[property] ||= Date.iso8601(data[property]) if property_schema['format'] == 'date'
+    data[property] = Date.iso8601(data[property]) if && property_schema.is_a?(Hash) && property_schema['format'] == 'date'
   end,
 
   # resolve external references

--- a/README.md
+++ b/README.md
@@ -95,14 +95,14 @@ JSONSchemer.schema(
   # modify properties during validation. You can pass one Proc or a list of Procs to modify data.
   # Proc/[Proc]
   # default: nil
-  before_property_validation: proc do |data, property, property_schema|
+  before_property_validation: proc do |data, property, property_schema, _parent|
     data[property] ||= 42
   end,
 
   # modify properties after validation. You can pass one Proc or a list of Procs to modify data.
   # Proc/[Proc]
   # default: nil
-  after_property_validation: proc do |data, property, property_schema|
+  after_property_validation: proc do |data, property, property_schema, _parent|
     data[property] = Date.iso8601(data[property]) if && property_schema.is_a?(Hash) && property_schema['format'] == 'date'
   end,
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ JSONSchemer.schema(
     data[property] ||= 42
   },
 
+  # modify properties after validation. You can pass one Proc or a list of Procs to modify data.
+  # Proc/[Proc]
+  # default: nil
+  after_validation: ->(data, property, property_schema) {
+    data[property] ||= Date.iso8601(data[property]) if property_schema['format'] == 'date'
+  },
+
   # resolve external references
   # 'net/http'/proc/lambda/respond_to?(:call)
   # 'net/http': proc { |uri| JSON.parse(Net::HTTP.get(uri)) }

--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ JSONSchemer.schema(
   # default: false
   insert_property_defaults: true,
 
+  # modify properties during validation. You can pass one Proc or a list of Procs to modify data.
+  # Proc/[Proc]
+  # default: nil
+  before_validation: ->(data, property, property_schema) {
+    data[property] ||= 42
+  },
+
   # resolve external references
   # 'net/http'/proc/lambda/respond_to?(:call)
   # 'net/http': proc { |uri| JSON.parse(Net::HTTP.get(uri)) }

--- a/README.md
+++ b/README.md
@@ -95,16 +95,16 @@ JSONSchemer.schema(
   # modify properties during validation. You can pass one Proc or a list of Procs to modify data.
   # Proc/[Proc]
   # default: nil
-  before_validation: ->(data, property, property_schema) {
+  before_property_validation: proc do |data, property, property_schema|
     data[property] ||= 42
-  },
+  end,
 
   # modify properties after validation. You can pass one Proc or a list of Procs to modify data.
   # Proc/[Proc]
   # default: nil
-  after_validation: ->(data, property, property_schema) {
+  after_property_validation: proc do |data, property, property_schema|
     data[property] ||= Date.iso8601(data[property]) if property_schema['format'] == 'date'
-  },
+  end,
 
   # resolve external references
   # 'net/http'/proc/lambda/respond_to?(:call)

--- a/lib/json_schemer/schema/base.rb
+++ b/lib/json_schemer/schema/base.rb
@@ -49,9 +49,9 @@ module JSONSchemer
         raise InvalidSymbolKey, 'schemas must use string keys' if schema.is_a?(Hash) && !schema.empty? && !schema.first.first.is_a?(String)
         @root = schema
         @format = format
-        @before_property_validation = Array(before_property_validation)
+        @before_property_validation = [*before_property_validation]
         @before_property_validation.unshift(INSERT_DEFAULT_PROPERTY) if insert_property_defaults
-        @after_property_validation = Array(after_property_validation)
+        @after_property_validation = [*after_property_validation]
         @formats = formats
         @keywords = keywords
         @ref_resolver = ref_resolver == 'net/http' ? CachedRefResolver.new(&NET_HTTP_REF_RESOLVER) : ref_resolver

--- a/lib/json_schemer/schema/base.rb
+++ b/lib/json_schemer/schema/base.rb
@@ -52,7 +52,7 @@ module JSONSchemer
         @before_validation = []
         @before_validation << INSERT_DEFAULT_PROPERTY if insert_property_defaults
         @before_validation += Array(before_validation) if before_validation
-        @after_validation = after_validation
+        @after_validation = Array(after_validation)
         @formats = formats
         @keywords = keywords
         @ref_resolver = ref_resolver == 'net/http' ? CachedRefResolver.new(&NET_HTTP_REF_RESOLVER) : ref_resolver

--- a/lib/json_schemer/schema/base.rb
+++ b/lib/json_schemer/schema/base.rb
@@ -30,7 +30,7 @@ module JSONSchemer
         :eol => '\z'
       }.freeze
 
-      INSERT_DEFAULT_PROPERTY = proc do |data, property, property_schema|
+      INSERT_DEFAULT_PROPERTY = proc do |data, property, property_schema, _parent|
         if !data.key?(property) && property_schema.is_a?(Hash) && property_schema.key?('default')
           data[property] = property_schema.fetch('default').clone
         end

--- a/lib/json_schemer/schema/base.rb
+++ b/lib/json_schemer/schema/base.rb
@@ -505,7 +505,7 @@ module JSONSchemer
         if instance.before_property_validation && properties
           properties.each do |property, property_schema|
             instance.before_property_validation.each do |hook|
-              hook.call(data, property, property_schema)
+              hook.call(data, property, property_schema, schema)
             end
           end
         end
@@ -584,7 +584,7 @@ module JSONSchemer
         if instance.after_property_validation && properties
           properties.each do |property, property_schema|
             instance.after_property_validation.each do |hook|
-              hook.call(data, property, property_schema)
+              hook.call(data, property, property_schema, schema)
             end
           end
         end

--- a/lib/json_schemer/schema/base.rb
+++ b/lib/json_schemer/schema/base.rb
@@ -49,9 +49,8 @@ module JSONSchemer
         raise InvalidSymbolKey, 'schemas must use string keys' if schema.is_a?(Hash) && !schema.empty? && !schema.first.first.is_a?(String)
         @root = schema
         @format = format
-        @before_property_validation = []
-        @before_property_validation << INSERT_DEFAULT_PROPERTY if insert_property_defaults
-        @before_property_validation += Array(before_property_validation) if before_property_validation
+        @before_property_validation = Array(before_property_validation)
+        @before_property_validation.unshift(INSERT_DEFAULT_PROPERTY) if insert_property_defaults
         @after_property_validation = Array(after_property_validation)
         @formats = formats
         @keywords = keywords

--- a/test/json_schemer_test.rb
+++ b/test/json_schemer_test.rb
@@ -298,6 +298,29 @@ class JSONSchemerTest < Minitest::Test
     assert_equal({'start_date' => Date.new(2020, 9, 3)}, data)
   end
 
+  def test_it_accepts_a_single_proc_as_after_validation_hook
+    convert_date = ->(data, property, property_schema) {
+      if data[property] && property_schema.is_a?(Hash) && property_schema['format'] == 'date'
+        data[property] = Date.iso8601(data[property])
+      end
+    }
+    schema = {
+      'properties' => {
+        'start_date' => {
+          'type' => 'string',
+          'format' => 'date'
+        }
+      }
+    }
+    validator= JSONSchemer.schema(
+      schema,
+      after_validation: convert_date
+    )
+    data = { 'start_date' => '2020-09-03' }
+    assert validator.valid?(data)
+    assert_equal({'start_date' => Date.new(2020, 9, 3)}, data)
+  end
+
   def test_it_does_not_fail_when_the_schema_is_completely_empty
     schema = {}
     data = {

--- a/test/json_schemer_test.rb
+++ b/test/json_schemer_test.rb
@@ -351,6 +351,24 @@ class JSONSchemerTest < Minitest::Test
     assert_equal({'start_date' => Date.new(2020, 9, 3)}, data)
   end
 
+  def test_it_does_not_modify_passed_hooks_array
+    schema = {
+      'properties' => {
+        'list' => {
+          'type' => 'array',
+          'items' => { 'type' => 'string' }
+        }
+      }
+    }
+    data = [{ 'name' => 'Bob' }]
+    assert JSONSchemer.schema(
+      schema,
+      before_property_validation: [proc {}].freeze,
+      after_property_validation: [proc {}].freeze,
+      insert_property_defaults: true
+    ).valid?(data)
+  end
+
   def test_it_does_not_fail_when_the_schema_is_completely_empty
     schema = {}
     data = {

--- a/test/json_schemer_test.rb
+++ b/test/json_schemer_test.rb
@@ -231,7 +231,7 @@ class JSONSchemerTest < Minitest::Test
     skip_read_only = proc do |data, property, property_schema, schema|
       return unless property_schema['readOnly']
       schema['required'].delete(property) if schema['required']
-      if data.key?(property) && property_schema.is_a?(Hash) &&
+      if data.key?(property) && property_schema.is_a?(Hash)
         data.delete(property)
       end
     end

--- a/test/json_schemer_test.rb
+++ b/test/json_schemer_test.rb
@@ -222,7 +222,7 @@ class JSONSchemerTest < Minitest::Test
     }
     assert JSONSchemer.schema(
       schema,
-      before_validation: [parse_array]
+      before_property_validation: [parse_array]
     ).valid?(data)
     assert_equal({'list' => [1, 2, 3]}, data)
   end
@@ -246,7 +246,7 @@ class JSONSchemerTest < Minitest::Test
     }
     assert JSONSchemer.schema(
       schema,
-      before_validation: parse_array
+      before_property_validation: parse_array
     ).valid?(data)
     assert_equal({'list' => [1, 2, 3]}, data)
   end
@@ -270,7 +270,7 @@ class JSONSchemerTest < Minitest::Test
         }
       },
       insert_property_defaults: true,
-      before_validation: [replace_fake_with_peter]
+      before_property_validation: [replace_fake_with_peter]
     ).valid?(data)
     assert_equal([{ 'name' => 'Peter' }, { 'name' => 'Bob' }], data)
   end
@@ -291,7 +291,7 @@ class JSONSchemerTest < Minitest::Test
     }
     validator= JSONSchemer.schema(
       schema,
-      after_validation: [convert_date]
+      after_property_validation: [convert_date]
     )
     data = { 'start_date' => '2020-09-03' }
     assert validator.valid?(data)
@@ -314,7 +314,7 @@ class JSONSchemerTest < Minitest::Test
     }
     validator= JSONSchemer.schema(
       schema,
-      after_validation: convert_date
+      after_property_validation: convert_date
     )
     data = { 'start_date' => '2020-09-03' }
     assert validator.valid?(data)

--- a/test/json_schemer_test.rb
+++ b/test/json_schemer_test.rb
@@ -275,6 +275,29 @@ class JSONSchemerTest < Minitest::Test
     assert_equal([{ 'name' => 'Peter' }, { 'name' => 'Bob' }], data)
   end
 
+  def test_it_calls_after_validation_hooks_to_modify_data
+    convert_date = ->(data, property, property_schema) {
+      if data[property] && property_schema.is_a?(Hash) && property_schema['format'] == 'date'
+        data[property] = Date.iso8601(data[property])
+      end
+    }
+    schema = {
+      'properties' => {
+        'start_date' => {
+          'type' => 'string',
+          'format' => 'date'
+        }
+      }
+    }
+    validator= JSONSchemer.schema(
+      schema,
+      after_validation: [convert_date]
+    )
+    data = { 'start_date' => '2020-09-03' }
+    assert validator.valid?(data)
+    assert_equal({'start_date' => Date.new(2020, 9, 3)}, data)
+  end
+
   def test_it_does_not_fail_when_the_schema_is_completely_empty
     schema = {}
     data = {


### PR DESCRIPTION
This adds `before_validation`, `after_validation` options to modify data before or after validation. The `insert_property_defaults` now is one of these before hooks.
One use case of this is to parse data based on your JSON Schema before or after the validation is run.

The after_validation option should basically solve https://github.com/davishmcclurg/json_schemer/issues/49.

In it's current state this only works when validating objects. 😬 What do you think?