### PR TITLE
Fixes "NoMethodError: undefined method `pointer'" for custom keyword

### DIFF
--- a/lib/json_schemer/schema/base.rb
+++ b/lib/json_schemer/schema/base.rb
@@ -112,7 +112,7 @@ module JSONSchemer
         if keywords
           keywords.each do |keyword, callable|
             if schema.key?(keyword)
-              result = callable.call(data, schema, instance)
+              result = callable.call(data, schema, instance.data_pointer)
               if result.is_a?(Array)
                 result.each(&block)
               elsif !result

--- a/lib/json_schemer/schema/base.rb
+++ b/lib/json_schemer/schema/base.rb
@@ -112,7 +112,7 @@ module JSONSchemer
         if keywords
           keywords.each do |keyword, callable|
             if schema.key?(keyword)
-              result = callable.call(data, schema, instance.pointer)
+              result = callable.call(data, schema, instance)
               if result.is_a?(Array)
                 result.each(&block)
               elsif !result

--- a/test/json_schemer_test.rb
+++ b/test/json_schemer_test.rb
@@ -1028,4 +1028,26 @@ class JSONSchemerTest < Minitest::Test
       end
     end
   end
+
+  def test_it_validates_correctly_custom_keywords
+    root = {
+      'type' => 'number',
+      'even' => true
+    }
+    options = {
+      keywords: {
+        'even' => lambda do |data, curr_schema, _pointer|
+          if curr_schema['even']
+            data.to_i.even?
+          else
+            data.to_i.odd?
+          end
+        end
+      }
+    }
+
+    schema = JSONSchemer.schema(root, options)
+    assert schema.valid?(2)
+    refute schema.valid?(3)
+  end
 end


### PR DESCRIPTION
I know that this feature is not described in the README file, but I came across the `keywords` option when navigating through the src code. This option is really helpful for my current project. 

However, when we try to pass custom validators through this, we get `"NoMethodError: undefined method 'pointer'"`.

Probably this is old code, that never got updated since the `instance` object does not contain that method anymore.

I took the liberty of passing the complete instance to the `callable` since it helps with the validation itself.

