### PR TITLE
Fixes for ruby 3.0.0.preview1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   ruby:
     strategy:
       matrix:
-        ruby: [2.4, 2.5, 2.6, 2.7, truffleruby-head]
+        ruby: [2.4, 2.5, 2.6, 2.7, head, truffleruby-head]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/json_schemer.gemspec
+++ b/json_schemer.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '~> 2.4'
+  spec.required_ruby_version = '>= 2.4'
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"

--- a/lib/json_schemer/format.rb
+++ b/lib/json_schemer/format.rb
@@ -101,7 +101,14 @@ module JSONSchemer
     end
 
     def iri_escape(data)
-      URI.escape(data, /[^[[:ascii:]]]/)
+      data.gsub(/[^[:ascii:]]/) do |match|
+        us = match
+        tmp = +''
+        us.each_byte do |uc|
+          tmp << sprintf('%%%02X', uc)
+        end
+        tmp
+      end.force_encoding(Encoding::US_ASCII)
     end
 
     def valid_uri_template?(data)

--- a/test/json_schemer_test.rb
+++ b/test/json_schemer_test.rb
@@ -1046,7 +1046,7 @@ class JSONSchemerTest < Minitest::Test
       }
     }
 
-    schema = JSONSchemer.schema(root, options)
+    schema = JSONSchemer.schema(root, **options)
     assert schema.valid?(2)
     refute schema.valid?(3)
   end


### PR DESCRIPTION
I replaced the call to URI.escape with the contents of URI.escape
such as it was, because it's removed in ruby 3.0.0.preview1
I assume there's a reason it's removed, so this is probably incomplete
at best, but at least it should continue to work as it did.

For this reason, & because 'uri_template' gem was throwing up a lot of
errors it may be a good idea to move to using the 'addressable' gem. but
for now i wanted to make as few changes as possible.

The only other change was adding an explicit splat to kwargs thing, and
changing the required ruby version to match 3.0.0.preview1 also.

Unfortunately there doesn't seem to be an obvious way to make it run 3.0.0.preview1 in actions ([look at this nonsense i had to do to make travis work for my own gem](https://github.com/robotdana/leftovers/pull/6/commits/439bdd52a42373e43094f809f875f96895074aa0#diff-6ac3f79fc25d95cd1e3d51da53a4b21b939437392578a35ae8cd6d5366ca5485R11-R14))