### PR TITLE
Bump ecma-re-validator and regexp_parser gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,20 +2,20 @@ PATH
   remote: .
   specs:
     json_schemer (0.2.16)
-      ecma-re-validator (~> 0.2)
+      ecma-re-validator (~> 0.3)
       hana (~> 1.3)
-      regexp_parser (~> 1.5)
+      regexp_parser (~> 2.0)
       uri_template (~> 0.7)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    ecma-re-validator (0.2.1)
-      regexp_parser (~> 1.2)
+    ecma-re-validator (0.3.0)
+      regexp_parser (~> 2.0)
     hana (1.3.6)
-    minitest (5.11.3)
+    minitest (5.14.2)
     rake (13.0.1)
-    regexp_parser (1.8.1)
+    regexp_parser (2.0.0)
     uri_template (0.7.0)
 
 PLATFORMS

--- a/json_schemer.gemspec
+++ b/json_schemer.gemspec
@@ -34,8 +34,8 @@ Gem::Specification.new do |spec|
   # spec.add_development_dependency "jsonschema", "~> 2.0.2"
   # spec.add_development_dependency "rj_schema", "~> 0.2.0"
 
-  spec.add_runtime_dependency "ecma-re-validator", "~> 0.2"
+  spec.add_runtime_dependency "ecma-re-validator", "~> 0.3"
   spec.add_runtime_dependency "hana", "~> 1.3"
   spec.add_runtime_dependency "uri_template", "~> 0.7"
-  spec.add_runtime_dependency "regexp_parser", "~> 1.5"
+  spec.add_runtime_dependency "regexp_parser", "~> 2.0"
 end


### PR DESCRIPTION
Many gems are now pointing to `regexp_parser` 2.0, I already bump the `ecma-re-validator` to support this new version whit allow the upgrade here too.
On the upgrade, the `minitest` was upgraded too.