### PR TITLE
Handle Windows paths in file ref resolver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ jobs:
         ruby: [2.4, 2.5, 2.6, 2.7, 3.0, head, jruby, jruby-head, truffleruby, truffleruby-head]
         exclude:
           - os: windows-latest
+            ruby: jruby
+          - os: windows-latest
+            ruby: jruby-head
+          - os: windows-latest
             ruby: truffleruby
           - os: windows-latest
             ruby: truffleruby-head

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,22 @@
 name: ci
 on: [push, pull_request]
 jobs:
-  ruby:
+  test:
     strategy:
+      fail-fast: false
       matrix:
-        ruby: [2.4, 2.5, 2.6, 2.7, head, truffleruby-head]
-    runs-on: ubuntu-latest
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        ruby: [2.4, 2.5, 2.6, 2.7, 3.0, head, jruby, jruby-head, truffleruby, truffleruby-head]
+        exclude:
+          - os: windows-latest
+            ruby: truffleruby
+          - os: windows-latest
+            ruby: truffleruby-head
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-    - run: |
-        bundle install
-        bundle exec rake test
+        bundler-cache: true
+    - run: bundle exec rake test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
     ecma-re-validator (0.3.0)
       regexp_parser (~> 2.0)
     hana (1.3.7)
-    minitest (5.14.2)
+    minitest (5.14.3)
     rake (13.0.1)
     regexp_parser (2.0.0)
     uri_template (0.7.0)
@@ -28,4 +28,4 @@ DEPENDENCIES
   rake (~> 13.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.11

--- a/lib/json_schemer.rb
+++ b/lib/json_schemer.rb
@@ -37,10 +37,14 @@ module JSONSchemer
 
   DEFAULT_META_SCHEMA = 'http://json-schema.org/draft-07/schema#'
 
+  WINDOWS_URI_PATH_REGEX = /\A\/[a-z]:/i
+
   FILE_URI_REF_RESOLVER = proc do |uri|
     raise InvalidFileURI, 'must use `file` scheme' unless uri.scheme == 'file'
     raise InvalidFileURI, 'cannot have a host (use `file:///`)' if uri.host && !uri.host.empty?
-    JSON.parse(File.read(uri.path))
+    path = uri.path
+    path = path[1..-1] if path.match?(WINDOWS_URI_PATH_REGEX)
+    JSON.parse(File.read(path))
   end
 
   class << self
@@ -49,7 +53,7 @@ module JSONSchemer
       when String
         schema = JSON.parse(schema)
       when Pathname
-        uri = URI.parse("file://#{schema.realpath}")
+        uri = URI.parse(File.join('file:', schema.realpath))
         if options.key?(:ref_resolver)
           schema = FILE_URI_REF_RESOLVER.call(uri)
         else

--- a/lib/json_schemer/format.rb
+++ b/lib/json_schemer/format.rb
@@ -61,7 +61,6 @@ module JSONSchemer
       DateTime.rfc3339(data)
       DATE_TIME_OFFSET_REGEX.match?(data)
     rescue ArgumentError => e
-      raise e unless e.message == 'invalid date'
       false
     end
 


### PR DESCRIPTION
Handle Windows paths in file ref resolver

Adding the `file://` prefix isn't working correctly on Windows because
it generates file URIs like: `file://c:/some/file`, which is treated
as if it has a host (`c:`):

```
JSONSchemer::InvalidFileURI:
  cannot have a host (use `file:///`)
```

This fixes that issue by prepending the `file` scheme with `File.join`.
Subsequently, `File.read` started failing because `File::URI#path`
returns Windows paths with a leading slash. I copied logic from
[`Gem::Util.correct_for_windows_path`][0] to remove the slash, because I
wasn't sure if it'd be safe to use directly. Their comment indicates
it's meant to handle similar issues:

```
  # Corrects +path+ (usually returned by `URI.parse().path` on Windows), that
  # comes with a leading slash.
```

Fixes: https://github.com/davishmcclurg/json_schemer/issues/87

[0]: https://github.com/ruby/ruby/blob/48b94b791997881929c739c64f95ac30f3fd0bb9/lib/rubygems/util.rb#L111