### PR TITLE
Use `BigDecimal` for `multiple_of` check

### DIFF
--- a/lib/json_schemer.rb
+++ b/lib/json_schemer.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'base64'
+require 'bigdecimal'
 require 'ipaddr'
 require 'json'
 require 'net/http'

--- a/lib/json_schemer/schema/base.rb
+++ b/lib/json_schemer/schema/base.rb
@@ -355,8 +355,7 @@ module JSONSchemer
         validate_exclusive_minimum(instance, exclusive_minimum, minimum, &block) if exclusive_minimum
 
         if multiple_of
-          quotient = data / multiple_of.to_f
-          yield error(instance, 'multipleOf') unless quotient.floor == quotient
+          yield error(instance, 'multipleOf') unless BigDecimal(data.to_s).modulo(multiple_of).zero?
         end
       end
 

--- a/test/json_schemer_test.rb
+++ b/test/json_schemer_test.rb
@@ -1050,4 +1050,10 @@ class JSONSchemerTest < Minitest::Test
     assert schema.valid?(2)
     refute schema.valid?(3)
   end
+
+  def test_it_handles_multiple_of_floats
+    assert JSONSchemer.schema({ 'multipleOf' => 0.01 }).valid?(8.61)
+    refute JSONSchemer.schema({ 'multipleOf' => 0.01 }).valid?(8.666)
+    assert JSONSchemer.schema({ 'multipleOf' => 0.001 }).valid?(8.666)
+  end
 end


### PR DESCRIPTION
Floats aren't accurate enough here.

Fixes: https://github.com/davishmcclurg/json_schemer/issues/100

Also addresses overflow exposed by: https://github.com/json-schema-org/JSON-Schema-Test-Suite/pull/438

```
FloatDomainError: Infinity
    /Users/dharsha/repos/json_schemer/lib/json_schemer/schema/base.rb:367:in `floor'
    /Users/dharsha/repos/json_schemer/lib/json_schemer/schema/base.rb:367:in `validate_numeric'
    /Users/dharsha/repos/json_schemer/lib/json_schemer/schema/base.rb:378:in `validate_number'
    /Users/dharsha/repos/json_schemer/lib/json_schemer/schema/base.rb:277:in `validate_type'
    /Users/dharsha/repos/json_schemer/lib/json_schemer/schema/base.rb:198:in `validate_instance'
```