### PR TITLE
Escape file paths when generating URI

### DIFF
--- a/lib/json_schemer.rb
+++ b/lib/json_schemer.rb
@@ -46,7 +46,7 @@ module JSONSchemer
     raise InvalidFileURI, 'cannot have a host (use `file:///`)' if uri.host && !uri.host.empty?
     path = uri.path
     path = path[1..-1] if path.match?(WINDOWS_URI_PATH_REGEX)
-    JSON.parse(File.read(path))
+    JSON.parse(File.read(URI::DEFAULT_PARSER.unescape(path)))
   end
 
   class << self
@@ -55,7 +55,7 @@ module JSONSchemer
       when String
         schema = JSON.parse(schema)
       when Pathname
-        uri = URI.parse(File.join('file:', schema.realpath))
+        uri = URI.parse(File.join('file:', URI::DEFAULT_PARSER.escape(schema.realpath.to_s)))
         if options.key?(:ref_resolver)
           schema = FILE_URI_REF_RESOLVER.call(uri)
         else

--- a/test/json_schemer_test.rb
+++ b/test/json_schemer_test.rb
@@ -1008,6 +1008,12 @@ class JSONSchemerTest < Minitest::Test
     refute(schema.valid?({ 'foo' => 1 }))
   end
 
+  def test_it_handles_spaces_in_schema_path
+    schema = JSONSchemer.schema(Pathname.new(__dir__).join('schemas', 'sp ce', 'sp ce.json'))
+    assert schema.valid?('yes')
+    refute schema.valid?(0)
+  end
+
   def test_json_schema_test_suite
     {
       'draft4' => JSONSchemer::Schema::Draft4,

--- a/test/schemas/sp ce/sp ce.json
+++ b/test/schemas/sp ce/sp ce.json
@@ -1,0 +1,1 @@
+{ "type": "string" }


### PR DESCRIPTION
File paths with spaces are causing `URI::InvalidURIError` errors:

```
>> URI.parse(File.join('file:', '/path/t o/schema.json'))
/Users/dharsha/.rbenv/versions/3.1.2/lib/ruby/3.1.0/uri/rfc3986_parser.rb:67:in `split': bad URI(is not URI?): "file:/path/t o/schema.json" (URI::InvalidURIError)
```

I think the correct fix is to escape paths when generating URIs and
unescape when reading files. I had a hard time finding the right
escape/unescape methods, though, since I think we want `%20` for spaces
instead of `+` and to leave slashes unescaped. `URI.escape` previously
did that but it's been deprecated for a while and removed in Ruby 3.
`URI::DEFAULT_PARSER` still has the same escape method and it doesn't
emit a warning, so I'm going with it.

Fixes: https://github.com/davishmcclurg/json_schemer/issues/104