### PR TITLE
Lazy-load files and dependencies

### DIFF
--- a/lib/json_schemer/format.rb
+++ b/lib/json_schemer/format.rb
@@ -1,4 +1,9 @@
 # frozen_string_literal: true
+require 'ecma-re-validator'
+require 'ipaddr'
+require 'time'
+require 'uri_template'
+
 module JSONSchemer
   module Format
     # this is no good

--- a/lib/json_schemer/schema/base.rb
+++ b/lib/json_schemer/schema/base.rb
@@ -1,4 +1,9 @@
 # frozen_string_literal: true
+require 'bigdecimal'
+require 'hana'
+require 'net/http'
+require 'regexp_parser'
+
 module JSONSchemer
   module Schema
     class Base


### PR DESCRIPTION
Calling `require 'json_schemer'` (or added the gem to Gemfile) eager-loads a lot of files and dependencies which adds to startup time and memory usage. The performance impact is tiny, but with many gems installed, it all adds up.

I suggest using Ruby's `autoload` feature to allow lazy-loading files and depencies. With this PR the number of files loaded is decreased from 98 to 12.

I used the following script to check how many files are included.

```
module Kernel
  alias_method :old_require, :require

  def require(file)
    loaded = old_require(file)
    puts file if loaded
    loaded
  end
end

$LOAD_PATH.unshift "#{__dir__}/lib"
require 'json_schemer'
```
