### PR TITLE
Small refactoring: extract validate_enum and validate_const methods

### DIFF
--- a/lib/json_schemer/schema/base.rb
+++ b/lib/json_schemer/schema/base.rb
@@ -84,7 +84,6 @@ module JSONSchemer
         return if schema == true || schema.empty?
 
         type = schema['type']
-        enum = schema['enum']
         all_of = schema['allOf']
         any_of = schema['anyOf']
         one_of = schema['oneOf']
@@ -122,7 +121,7 @@ module JSONSchemer
           end
         end
 
-        yield error(instance, 'enum') if enum && !enum.include?(data)
+        validate_enum(instance, &block)
         yield error(instance, 'const') if schema.key?('const') && schema['const'] != data
 
         if all_of
@@ -587,6 +586,13 @@ module JSONSchemer
             end
           end
         end
+      end
+
+      def validate_enum(instance, &block)
+        enum = instance.schema['enum']
+        data = instance.data
+
+        yield error(instance, 'enum') if enum && !enum.include?(data)
       end
 
       def safe_strict_decode64(data)

--- a/lib/json_schemer/schema/base.rb
+++ b/lib/json_schemer/schema/base.rb
@@ -122,7 +122,7 @@ module JSONSchemer
         end
 
         validate_enum(instance, &block)
-        yield error(instance, 'const') if schema.key?('const') && schema['const'] != data
+        validate_const(instance, &block)
 
         if all_of
           all_of.each_with_index do |subschema, index|
@@ -593,6 +593,13 @@ module JSONSchemer
         data = instance.data
 
         yield error(instance, 'enum') if enum && !enum.include?(data)
+      end
+
+      def validate_const(instance, &block)
+        data = instance.data
+        schema = instance.schema
+
+        yield error(instance, 'const') if schema.key?('const') && schema['const'] != data
       end
 
       def safe_strict_decode64(data)


### PR DESCRIPTION
In order to be able to override how we're validating enums and const we need to first extract it as separate methods, so we're able to take advantage of the inheritance and override that small methods.

This won't affect the current codebase but will allow us to start working on supporting draft 2020-12 based on that.