### PR TITLE
Add `anonymous` keyword to avoid $id fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,10 @@ JSONSchemer.schema(
   # 'net/http'/proc/lambda/respond_to?(:call)
   # 'net/http': proc { |uri| JSON.parse(Net::HTTP.get(uri)) }
   # default: proc { |uri| raise UnknownRef, uri.to_s }
-  ref_resolver: 'net/http'
+  ref_resolver: 'net/http',
+
+  # do not compute a fallback $id for schemas lacking one
+  anonymous: true
 )
 ```
 

--- a/lib/json_schemer.rb
+++ b/lib/json_schemer.rb
@@ -63,8 +63,9 @@ module JSONSchemer
           schema = ref_resolver.call(uri)
           options[:ref_resolver] = ref_resolver
         end
-        schema[draft_class(schema)::ID_KEYWORD] ||= uri.to_s
+        schema[draft_class(schema)::ID_KEYWORD] ||= uri.to_s unless options.key?(:anonymous)
       end
+      options.delete(:anonymous)
       draft_class(schema).new(schema, **options)
     end
 

--- a/lib/json_schemer/schema/base.rb
+++ b/lib/json_schemer/schema/base.rb
@@ -36,6 +36,8 @@ module JSONSchemer
         end
       end
 
+      attr_reader :root
+
       def initialize(
         schema,
         format: true,
@@ -204,7 +206,7 @@ module JSONSchemer
 
     private
 
-      attr_reader :root, :formats, :keywords, :ref_resolver
+      attr_reader :formats, :keywords, :ref_resolver
 
       def id_keyword
         ID_KEYWORD

--- a/test/json_schemer_test.rb
+++ b/test/json_schemer_test.rb
@@ -1084,4 +1084,10 @@ class JSONSchemerTest < Minitest::Test
     refute(JSONSchemer.schema({ 'multipleOf' => 0.01 }).valid?(8.666))
     assert(JSONSchemer.schema({ 'multipleOf' => 0.001 }).valid?(8.666))
   end
+
+  def test_it_affords_anonymous_schema_from_pathname
+    schema = JSONSchemer.schema(Pathname.new(__dir__).join('schemas', 'subschemas', 'schema2.json'), anonymous: true)
+    assert(!schema.root.key?(JSONSchemer::Schema::Base::ID_KEYWORD))
+    assert(schema.valid?({ 'id' => 1 }))
+  end
 end


### PR DESCRIPTION
Currently, when a schema lacks an `$id` property, a `file://...` fallback is computed. This is not desirable for schemas which are kept anonymous intentionally. This PR adds the `:anonymous` keyword which avoids the fallback.

To clarify the need, we serialize a schema from a Rails controller, using ActiveSupport's `as_json` extension (which reads instance variables):

```ruby
SCHEMA = JSONSchemer.schema(PATH)

def schema
  render json: SCHEMA.as_json['root'].except('$id')
end
```

As this PR also introduces an `attr_reader :root`, we can then accomplish the same as:

```ruby
SCHEMA = JSONSchemer.schema(PATH, anonymous: true)

def schema
  render json: SCHEMA.root
end
```