### PR TITLE
Add named regexp resolvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ JSONSchemer.schema(
   ref_resolver: 'net/http',
   
   # use different method to match regexes
-  # Proc/lambda/respond_to?(:call)
+  # 'ecma'/'ruby'/proc/lambda/respond_to?(:call)
+  # default: 'ecma'
   regexp_resolver: proc do |pattern|
     RE2::Regexp.new(pattern)
   end

--- a/test/json_schemer_test.rb
+++ b/test/json_schemer_test.rb
@@ -933,6 +933,18 @@ class JSONSchemerTest < Minitest::Test
     assert_equal(1, new_regexp_class.counts)
   end
 
+  def test_it_allows_named_regexp_resolvers
+    schema = JSONSchemer.schema({ 'pattern' => '^test$' })
+    assert(schema.valid?("test"))
+    refute(schema.valid?("\ntest\n"))
+    schema = JSONSchemer.schema({ 'pattern' => '^test$' }, :regexp_resolver => 'ecma')
+    assert(schema.valid?("test"))
+    refute(schema.valid?("\ntest\n"))
+    schema = JSONSchemer.schema({ 'pattern' => '^test$' }, :regexp_resolver => 'ruby')
+    assert(schema.valid?("test"))
+    assert(schema.valid?("\ntest\n"))
+  end
+
   def test_it_raises_for_invalid_regexp_resolution
     schema = JSONSchemer.schema(
       { 'pattern' => 'whatever' },


### PR DESCRIPTION
`ecma` maintains the current behavior of rewriting Ruby's `\A` and `\z` anchors.
`ruby` uses Ruby's `Regexp` directly.

In the future, I think it may make sense to switch the default to `ruby` since it's the least surprising behavior. That way people could opt in to expression rewrites and the rewrites could be more aggressive.