### PR TITLE
Fix specs on CI on TruffleRuby

### DIFF
--- a/lib/json_schemer/schema/base.rb
+++ b/lib/json_schemer/schema/base.rb
@@ -416,7 +416,7 @@ module JSONSchemer
 
         yield error(instance, 'maxLength') if max_length && data.size > max_length
         yield error(instance, 'minLength') if min_length && data.size < min_length
-        yield error(instance, 'pattern') if pattern && resolve_regexp(pattern) !~ data
+        yield error(instance, 'pattern') if pattern && !resolve_regexp(pattern).match?(data)
         yield error(instance, 'format') if format? && spec_format?(format) && !valid_spec_format?(data, format)
 
         if content_encoding || content_media_type

--- a/test/json_schemer_test.rb
+++ b/test/json_schemer_test.rb
@@ -927,8 +927,8 @@ class JSONSchemerTest < Minitest::Test
         self.class.counts += 1
       end
 
-      def !~(string)
-        @regexp !~ string
+      def match?(string)
+        @regexp.match?(string)
       end
     end
 


### PR DESCRIPTION
Don't create Regexp subclass in tests.

On CI ([example](https://github.com/davishmcclurg/json_schemer/actions/runs/3333968277/jobs/5516444862)) one spec fails on TruffleRuby with error:

```
1) Failure:
JSONSchemerTest#test_it_handles_regexp_resolver [/home/runner/work/json_schemer/json_schemer/test/json_schemer_test.rb:933]:
Expected: 1
  Actual: 0
```

This test was introduced in the PR https://github.com/davishmcclurg/json_schemer/pull/111.

TruffleRuby doesn't support instantiating Regexp subclasse (in fact they will be instances of Regexp, not a subclass). So I modified the test to avoid inheriting Regexp.

It seems to me that it's a correct change as far as _regexp resolver_ doesn't need to return an instance of Regexp class. It should return something like regexp that implements some expected interface (`#!~` method in our case).

cc @eregon