### PR TITLE
Escape JSON pointer tokens

### DIFF
--- a/test/json_schemer_test.rb
+++ b/test/json_schemer_test.rb
@@ -1156,4 +1156,21 @@ class JSONSchemerTest < Minitest::Test
     refute(JSONSchemer.schema({ 'multipleOf' => 0.01 }).valid?(8.666))
     assert(JSONSchemer.schema({ 'multipleOf' => 0.001 }).valid?(8.666))
   end
+
+  def test_it_escapes_json_pointer_tokens
+    schemer = JSONSchemer.schema(
+      {
+        'type' => 'object',
+        'properties' => {
+          'foo/bar~' => {
+            'type' => 'string'
+          }
+        }
+    }
+    )
+    errors = schemer.validate({ 'foo/bar~' => 1 }).to_a
+    assert_equal(1, errors.size)
+    assert_equal('/foo~1bar~0', errors.first.fetch('data_pointer'))
+    assert_equal('/properties/foo~1bar~0', errors.first.fetch('schema_pointer'))
+  end
 end


### PR DESCRIPTION
When building `data_pointer` and `schema_pointer` in error objects.

[JSON Pointer RFC][0]:

```
Because the characters '~' (%x7E) and '/' (%x2F) have special
meanings in JSON Pointer, '~' needs to be encoded as '~0' and '/'
needs to be encoded as '~1' when these characters appear in a
reference token.
```

Fixes: https://github.com/davishmcclurg/json_schemer/issues/121

[0]: https://www.rfc-editor.org/rfc/rfc6901#section-3