### PR TITLE
Support regexp_parser < 2.3.0

### DIFF
--- a/lib/json_schemer/ecma_regexp.rb
+++ b/lib/json_schemer/ecma_regexp.rb
@@ -2,19 +2,26 @@
 module JSONSchemer
   class EcmaRegexp
     class Syntax < Regexp::Syntax::Base
-      implements :anchor, Anchor::Extended
-      implements :assertion, Assertion::All
-      implements :backref, Backreference::Plain + Backreference::Name
-      implements :escape, Escape::Basic + %i[control backspace form_feed newline carriage tab vertical_tab] + Escape::Unicode + Escape::Meta + Escape::Hex + Escape::Octal
-      implements :property, UnicodeProperty::All
-      implements :nonproperty, UnicodeProperty::All
-      implements :free_space, %i[whitespace]
-      implements :group, Group::Basic + Group::Named + Group::Passive
-      implements :literal, Literal::All
-      implements :meta, Meta::Extended
-      implements :quantifier, Quantifier::Greedy + Quantifier::Reluctant + Quantifier::Interval + Quantifier::IntervalReluctant
-      implements :set, CharacterSet::Basic
-      implements :type, CharacterType::Extended
+      # regexp_parser >= 2.3.0 uses syntax classes directly instead of instances
+      # :nocov:
+      SYNTAX = respond_to?(:implements) ? self : new
+      # :nocov:
+      SYNTAX.implements :anchor, Anchor::Extended
+      SYNTAX.implements :assertion, Assertion::All
+      # literal %i[number] to support regexp_parser < 2.2.0 (Backreference::Plain)
+      SYNTAX.implements :backref, %i[number] + Backreference::Name
+      # :meta_sequence, :bell, and :escape are not supported in ecma
+      SYNTAX.implements :escape, Escape::Basic + (Escape::Control - %i[meta_sequence]) + (Escape::ASCII - %i[bell escape]) + Escape::Unicode + Escape::Meta + Escape::Hex + Escape::Octal
+      SYNTAX.implements :property, UnicodeProperty::All
+      SYNTAX.implements :nonproperty, UnicodeProperty::All
+      # :comment is not supported in ecma
+      SYNTAX.implements :free_space, (FreeSpace::All - %i[comment])
+      SYNTAX.implements :group, Group::Basic + Group::Named + Group::Passive
+      SYNTAX.implements :literal, Literal::All
+      SYNTAX.implements :meta, Meta::Extended
+      SYNTAX.implements :quantifier, Quantifier::Greedy + Quantifier::Reluctant + Quantifier::Interval + Quantifier::IntervalReluctant
+      SYNTAX.implements :set, CharacterSet::Basic
+      SYNTAX.implements :type, CharacterType::Extended
     end
 
     RUBY_EQUIVALENTS = {
@@ -31,7 +38,7 @@ module JSONSchemer
     class << self
       def ruby_equivalent(pattern)
         Regexp::Scanner.scan(pattern).map do |type, token, text|
-          Syntax.check!(*Syntax.normalize(type, token))
+          Syntax::SYNTAX.check!(*Syntax::SYNTAX.normalize(type, token))
           RUBY_EQUIVALENTS.dig(type, token) || text
         rescue Regexp::Syntax::NotImplementedError
           raise InvalidEcmaRegexp, "invalid token #{text.inspect} (#{type}:#{token}) in #{pattern.inspect}"


### PR DESCRIPTION
In 2.3.0, regexp_parser switched to using `Syntax` classes directly instead of creating instances. You get a bunch of warnings if you use instances in later versions. To support earlier versions, this checks where `implements` is defined and creates an instance if necessary.

Also had to stop using `Backreference::Plain` because it was introduced in 2.2.0. This replaces it with its value: `%i[number]`.

I also switched to removing unsupported tokens from predefined sets so that it's a little easier to understand how these were built:

- `(Escape::Control - %i[meta_sequence])`
- `(Escape::ASCII - %i[bell escape])`
- `(FreeSpace::All - %i[comment])`