### PR TITLE
Get Truffleruby tests passing

### DIFF
--- a/lib/json_schemer/format.rb
+++ b/lib/json_schemer/format.rb
@@ -66,7 +66,7 @@ module JSONSchemer
     def valid_date_time?(data)
       return false if HOUR_24_REGEX.match?(data)
       datetime = DateTime.rfc3339(data)
-      return false if LEAP_SECOND_REGEX.match?(data) && datetime.to_time.utc.strftime('%H:%M') != '23:59'
+      return false if LEAP_SECOND_REGEX.match?(data) && datetime.new_offset.strftime('%H:%M') != '23:59'
       DATE_TIME_OFFSET_REGEX.match?(data)
     rescue ArgumentError
       false


### PR DESCRIPTION
Truffleruby is pickier about `Time` offsets for some reason.

Should be able to remove the test suite changes once Truffleruby upgrades the built-in json gem to [v2.6.3][0], which I think is supposed to happen in [v23.1][1].

[0]: https://github.com/flori/json/releases/tag/v2.6.3
[1]: https://github.com/oracle/truffleruby/blob/master/CHANGELOG.md#2310