### PR TITLE
Return parent base URI when resolving ids

### DIFF
--- a/test/json_schema_test_suite_test.rb
+++ b/test/json_schema_test_suite_test.rb
@@ -14,7 +14,7 @@ class JSONSchemaTestSuiteTest < Minitest::Test
   end
 
   def test_json_schema_test_suite
-    ref_resolver = proc do |uri|
+    ref_resolver = JSONSchemer::CachedResolver.new do |uri|
       if uri.host == 'localhost'
         path = Pathname.new(__dir__).join('..', 'JSON-Schema-Test-Suite', 'remotes', uri.path.gsub(/\A\//, ''))
         JSON.parse(path.read)


### PR DESCRIPTION
This is necessary because `$id` values are joined with the base URI when
the [instance is validated][0] as well as when [ref JSON pointers are
resolved][1]. This returns the parent base URI instead so that calling
`join_uri` later will generate the correct base URI. There's probably a
better way to do this but I get confused thinking it through.

This came up while working on adding support for draft 2019-09, which
has [tests][2] that caused issues. That's where I pulled these tests
from.

[0]: https://github.com/davishmcclurg/json_schemer/blob/c33c1b91ca831c01270cd7d14f927b8727022dee/lib/json_schemer/schema/base.rb#L137
[1]: https://github.com/davishmcclurg/json_schemer/blob/c33c1b91ca831c01270cd7d14f927b8727022dee/lib/json_schemer/schema/base.rb#L340
[2]: https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/b069ac352c3dc1fae71f6f177dafe97001c97920/tests/draft2019-09/refRemote.json#L101-L160