### PR TITLE
Resolve JSON pointer refs locally

### DIFF
--- a/lib/json_schemer/schema/base.rb
+++ b/lib/json_schemer/schema/base.rb
@@ -324,7 +324,7 @@ module JSONSchemer
           ref_uri.fragment = nil
         end
 
-        ref_object = if ids.key?(ref_uri) || ref_uri.to_s == @base_uri.to_s
+        ref_object = if ids.key?(ref_uri) || ref_uri.to_s.empty? || ref_uri.to_s == @base_uri.to_s
           self
         else
           child(resolve_ref(ref_uri), base_uri: ref_uri)

--- a/test/ref_test.rb
+++ b/test/ref_test.rb
@@ -301,4 +301,27 @@ class RefTest < Minitest::Test
     assert(schema.valid?({ 'list' => [1] }))
     refute(schema.valid?({ 'list' => ['a'] }))
   end
+
+  def test_it_handles_relative_base_uri_json_pointer_ref
+    refs = {
+      'relative' => {
+        'definitions' => {
+          'foo' => {
+            'type' => 'integer'
+          }
+        },
+        'properties' => {
+          'bar' => {
+            '$ref' => '#/definitions/foo'
+          }
+        }
+      }
+    }
+    schema = JSONSchemer.schema(
+      { '$ref' => 'relative' },
+      :ref_resolver => proc { |uri| refs[uri.to_s] }
+    )
+    assert(schema.valid?({ 'bar' => 1 }))
+    refute(schema.valid?({ 'bar' => '1' }))
+  end
 end


### PR DESCRIPTION
When `instance.base_uri` is relaive and `ref` is a JSON pointer fragment, the fragment is removed from `ref_uri` which causes it to be empty. The ref is meant to be resolved locally, but it was being passed to `resolve_ref` instead. I thought this case was covered by the `ref_uri.to_s == @base_uri.to_s` check, but it's currently possible (though incorrect?) for `@base_uri` to be relative.

Checking `ref_uri.to_s.empty?` should be ok since it means `ref` was a plain JSON pointer fragment (eg, `#/path/to/schema`).

Example here: https://github.com/davishmcclurg/json_schemer/issues/131

Closes: https://github.com/davishmcclurg/json_schemer/issues/131