### PR TITLE
Use `bundle exec` for executable tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,4 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-    - run: |
-        mkdir -p tmp/gems
-        gem build json_schemer.gemspec
-        gem install --local --ignore-dependencies --no-document --install-dir tmp/gems json_schemer-*.gem
-        rm json_schemer-*.gem
-        bin/rake test
+    - run: bin/rake test


### PR DESCRIPTION
`bundle install` installs executables from local source:

```
Using json_schemer 1.0.3 from source at `.` and installing its executables
```

Using `bundle exec` makes it easier to test things when switching between Ruby versions since it's not necessary to rebuild the gem manually.

Ruby 2.5 emits a warning about RubyGems that I had to strip to get tests to pass.