### PR TITLE
Support custom error messages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,13 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    concurrent-ruby (1.2.2)
     docile (1.4.0)
     hana (1.3.7)
+    i18n (1.14.1)
+      concurrent-ruby (~> 1.0)
+    i18n-debug (1.2.0)
+      i18n (< 2)
     minitest (5.15.0)
     rake (13.0.6)
     regexp_parser (2.8.1)
@@ -33,6 +38,8 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 2.0)
+  i18n
+  i18n-debug
   json_schemer!
   minitest (~> 5.0)
   rake (~> 13.0)

--- a/json_schemer.gemspec
+++ b/json_schemer.gemspec
@@ -26,6 +26,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "simplecov", "~> 0.22"
+  spec.add_development_dependency "i18n"
+  spec.add_development_dependency "i18n-debug"
 
   spec.add_runtime_dependency "hana", "~> 1.3"
   spec.add_runtime_dependency "regexp_parser", "~> 2.0"

--- a/lib/json_schemer/draft202012/vocab.rb
+++ b/lib/json_schemer/draft202012/vocab.rb
@@ -16,7 +16,9 @@ module JSONSchemer
         '$defs' => Core::Defs,
         'definitions' => Core::Defs,
         # https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-01#section-8.3
-        '$comment' => Core::Comment
+        '$comment' => Core::Comment,
+        # https://github.com/orgs/json-schema-org/discussions/329
+        'x-error' => Core::XError
       }
       # https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-01#section-10
       APPLICATOR = {

--- a/lib/json_schemer/draft202012/vocab/core.rb
+++ b/lib/json_schemer/draft202012/vocab/core.rb
@@ -119,6 +119,12 @@ module JSONSchemer
 
         class Comment < Keyword; end
 
+        class XError < Keyword
+          def message(error_key)
+            value.is_a?(Hash) ? (value[error_key] || value[CATCHALL]) : value
+          end
+        end
+
         class UnknownKeyword < Keyword
           def parse
             if value.is_a?(Hash)

--- a/lib/json_schemer/keyword.rb
+++ b/lib/json_schemer/keyword.rb
@@ -26,6 +26,10 @@ module JSONSchemer
       @schema_pointer ||= "#{parent.schema_pointer}/#{escaped_keyword}"
     end
 
+    def error_key
+      keyword
+    end
+
   private
 
     def parse

--- a/lib/json_schemer/output.rb
+++ b/lib/json_schemer/output.rb
@@ -5,6 +5,11 @@ module JSONSchemer
 
     attr_reader :keyword, :schema
 
+    def x_error
+      return @x_error if defined?(@x_error)
+      @x_error = schema.parsed['x-error']&.message(error_key)
+    end
+
   private
 
     def result(instance, instance_location, keyword_location, valid, nested = nil, type: nil, annotation: nil, details: nil, ignore_nested: false)

--- a/lib/json_schemer/schema.rb
+++ b/lib/json_schemer/schema.rb
@@ -287,6 +287,10 @@ module JSONSchemer
       end
     end
 
+    def error_key
+      '^'
+    end
+
     def fetch_format(format, *args, &block)
       if meta_schema == self
         formats.fetch(format, *args, &block)

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -1,0 +1,243 @@
+require 'test_helper'
+
+class ErrorsTest < Minitest::Test
+  def test_x_error
+    schema = {
+      'oneOf' => [
+        {
+          'x-error' => 'properties a and b were provided, however only one or the other may be specified',
+          'required' => ['a'],
+          'not' => { 'required' => ['b'] }
+        },
+        {
+          'x-error' => {
+            'not' => '%{instance} `%{instanceLocation}` %{keywordLocation} %{absoluteKeywordLocation}'
+          },
+          'required' => ['b'],
+          'not' => { 'required' => ['a'] }
+        }
+      ],
+      'x-error' => {
+        '*' => 'schema error',
+        'oneOf' => 'oneOf error'
+      }
+    }
+    data = {
+      'a' => 'foo',
+      'b' => 'bar'
+    }
+    assert_equal(
+      [
+        'properties a and b were provided, however only one or the other may be specified',
+        '{"a"=>"foo", "b"=>"bar"} `` /oneOf/1/not json-schemer://schema#/oneOf/1/not'
+      ].sort,
+      JSONSchemer.schema(schema).validate(data).map { |error| error.fetch('error') }.sort
+    )
+
+    assert_equal('schema error', JSONSchemer.schema(schema).validate(data, :output_format => 'basic').fetch('error'))
+    assert_equal('oneOf error', JSONSchemer.schema(schema).validate(data, :output_format => 'detailed').fetch('error'))
+  end
+
+  def test_x_error_override
+    schema = {
+      'required' => ['a'],
+      'minProperties' => 2
+    }
+    assert_equal(
+      ['object at root is missing required properties: a', 'object size at root is less than: 2'].sort,
+      JSONSchemer.schema(schema).validate({}).map { |error| error.fetch('error') }.sort
+    )
+
+    schema.merge!('x-error' => 'schema error')
+    assert_equal(
+      ['schema error', 'schema error'].sort,
+      JSONSchemer.schema(schema).validate({}).map { |error| error.fetch('error') }.sort
+    )
+    assert_equal(
+      'schema error',
+      JSONSchemer.schema(schema).validate({}, :output_format => 'basic').fetch('error')
+    )
+
+    schema.merge!('x-error' => { 'required' => 'required error' })
+    assert_equal(
+      ['required error', 'object size at root is less than: 2'].sort,
+      JSONSchemer.schema(schema).validate({}).map { |error| error.fetch('error') }.sort
+    )
+
+    schema.merge!('x-error' => { 'required' => 'required error', 'minProperties' => 'minProperties error' })
+    assert_equal(
+      ['required error', 'minProperties error'].sort,
+      JSONSchemer.schema(schema).validate({}).map { |error| error.fetch('error') }.sort
+    )
+
+    schema.merge!('x-error' => { '*' => 'catchall', 'minProperties' => 'minProperties error' })
+    assert_equal(
+      ['catchall', 'minProperties error'].sort,
+      JSONSchemer.schema(schema).validate({}).map { |error| error.fetch('error') }.sort
+    )
+    assert_equal(
+      'catchall',
+      JSONSchemer.schema(schema).validate({}, :output_format => 'basic').fetch('error')
+    )
+
+    schema.merge!('x-error' => { '^' => 'schema error', 'minProperties' => 'minProperties error' })
+    assert_equal(
+      ['object at root is missing required properties: a', 'minProperties error'].sort,
+      JSONSchemer.schema(schema).validate({}).map { |error| error.fetch('error') }.sort
+    )
+    assert_equal(
+      'schema error',
+      JSONSchemer.schema(schema).validate({}, :output_format => 'basic').fetch('error')
+    )
+
+    schema.merge!('x-error' => { '^' => 'schema error', '*' => 'catchall' })
+    assert_equal(
+      ['catchall', 'catchall'].sort,
+      JSONSchemer.schema(schema).validate({}).map { |error| error.fetch('error') }.sort
+    )
+    assert_equal(
+      'schema error',
+      JSONSchemer.schema(schema).validate({}, :output_format => 'basic').fetch('error')
+    )
+  end
+
+  def test_x_error_precedence
+    schema = {
+      '$id' => 'https://example.com/schema',
+      'required' => ['a']
+    }
+    x_error_schema = schema.merge(
+      'x-error' => {
+        'required' => 'x error'
+      }
+    )
+
+    assert_equal('x error', JSONSchemer.schema(x_error_schema).validate({}).first.fetch('error'))
+    assert_equal('object at root is missing required properties: a', JSONSchemer.schema(schema).validate({}).first.fetch('error'))
+
+    i18n({ 'https://example.com/schema#/required' => 'i18n error' }) do
+      assert_equal('x error', JSONSchemer.schema(x_error_schema).validate({}).first.fetch('error'))
+      assert_equal('i18n error', JSONSchemer.schema(schema).validate({}).first.fetch('error'))
+    end
+  end
+
+  def test_i18n_error
+    schema = {
+      '$id' => 'https://example.com/schema',
+      '$schema' => 'https://json-schema.org/draft/2019-09/schema',
+      'properties' => {
+        'yah' => {
+          'type' => 'string'
+        }
+      }
+    }
+    schemer = JSONSchemer.schema(schema)
+    data = { 'yah' => 1 }
+
+    errors = {
+      'https://example.com/schema#' => 'A',
+      'https://example.com/schema#/properties/yah/type' => '1',
+      'https://example.com/schema' => {
+        '#' => 'B',
+        '#/properties/yah/type' => '2',
+        '^' => 'D',
+        'type' => '4',
+        '*' => 'E/5'
+      },
+      '#/properties/yah/type' => '3',
+      '#' => 'C',
+      'https://json-schema.org/draft/2019-09/schema' => {
+        '^' => 'F',
+        'type' => '6',
+        '*' => 'G/7'
+      },
+      '^' => 'H',
+      'type' => '8',
+      '*' => 'I/9',
+
+      'https://example.com/differentschema#/properties/yah/type' => '?',
+      'https://example.com/differentschema' => {
+        '#/properties/yah/type' => '?',
+        'type' => '?',
+        '*' => '?'
+      },
+      '?' => '?'
+    }
+    assert_equal('A', i18n(errors) { schemer.validate(data, :output_format => 'basic').fetch('error') })
+    assert_equal('1', i18n(errors) { schemer.validate(data).first.fetch('error') })
+
+    errors.delete('https://example.com/schema#')
+    assert_equal('B', i18n(errors) { schemer.validate(data, :output_format => 'basic').fetch('error') })
+
+    errors.delete('https://example.com/schema#/properties/yah/type')
+    assert_equal('2', i18n(errors) { schemer.validate(data).first.fetch('error') })
+
+    errors.fetch('https://example.com/schema').delete('#')
+    assert_equal('C', i18n(errors) { schemer.validate(data, :output_format => 'basic').fetch('error') })
+
+    errors.fetch('https://example.com/schema').delete('#/properties/yah/type')
+    assert_equal('3', i18n(errors) { schemer.validate(data).first.fetch('error') })
+
+    errors.delete('#')
+    assert_equal('D', i18n(errors) { schemer.validate(data, :output_format => 'basic').fetch('error') })
+
+    errors.delete('#/properties/yah/type')
+    assert_equal('4', i18n(errors) { schemer.validate(data).first.fetch('error') })
+
+    errors.fetch('https://example.com/schema').delete('^')
+    assert_equal('E/5', i18n(errors) { schemer.validate(data, :output_format => 'basic').fetch('error') })
+
+    errors.fetch('https://example.com/schema').delete('type')
+    assert_equal('E/5', i18n(errors) { schemer.validate(data).first.fetch('error') })
+
+    errors.fetch('https://example.com/schema').delete('*')
+    assert_equal('F', i18n(errors) { schemer.validate(data, :output_format => 'basic').fetch('error') })
+    assert_equal('6', i18n(errors) { schemer.validate(data).first.fetch('error') })
+
+    errors.fetch('https://json-schema.org/draft/2019-09/schema').delete('^')
+    assert_equal('G/7', i18n(errors) { schemer.validate(data, :output_format => 'basic').fetch('error') })
+
+    errors.fetch('https://json-schema.org/draft/2019-09/schema').delete('type')
+    assert_equal('G/7', i18n(errors) { schemer.validate(data).first.fetch('error') })
+
+    errors.fetch('https://json-schema.org/draft/2019-09/schema').delete('*')
+    assert_equal('H', i18n(errors) { schemer.validate(data, :output_format => 'basic').fetch('error') })
+    assert_equal('8', i18n(errors) { schemer.validate(data).first.fetch('error') })
+
+    errors.delete('^')
+    assert_equal('I/9', i18n(errors) { schemer.validate(data, :output_format => 'basic').fetch('error') })
+
+    errors.delete('type')
+    assert_equal('I/9', i18n(errors) { schemer.validate(data).first.fetch('error') })
+
+    errors.delete('*')
+    assert_equal('value at root does not match schema', i18n(errors) { schemer.validate(data, :output_format => 'basic').fetch('error') })
+    assert_equal('value at `/yah` is not a string', i18n(errors) { schemer.validate(data).first.fetch('error') })
+  end
+
+private
+
+  def i18n(errors)
+    require 'yaml'
+    require 'i18n'
+    # require 'i18n/debug'
+
+    JSONSchemer.remove_class_variable(:@@i18n) if JSONSchemer.class_variable_defined?(:@@i18n)
+    # @on_lookup ||= I18n::Debug.on_lookup
+    # I18n::Debug.on_lookup(&@on_lookup)
+
+    Tempfile.create(['translations', '.yml']) do |file|
+      file.write(YAML.dump({ 'en' => { 'json_schemer' => { 'errors' => errors } } }))
+      file.flush
+
+      I18n.load_path += [file.path]
+
+      yield
+    ensure
+      I18n.load_path -= [file.path]
+    end
+  ensure
+    JSONSchemer.remove_class_variable(:@@i18n) if JSONSchemer.class_variable_defined?(:@@i18n)
+    # I18n::Debug.on_lookup {}
+  end
+end

--- a/test/exe_test.rb
+++ b/test/exe_test.rb
@@ -175,7 +175,9 @@ private
 
   def exe(*args, **kwargs)
     Open3.capture3('bundle', 'exec', 'json_schemer', *args, **kwargs).tap do |_stdout, stderr, _status|
+      # :nocov:
       stderr.gsub!(RUBY_2_5_WARNING_REGEX, '') if RUBY_ENGINE == 'ruby' && RUBY_VERSION.match?(/\A2\.5\.\d+\z/)
+      # :nocov:
     end
   end
 


### PR DESCRIPTION
This introduces two ways of defining custom error messages: the `x-error` keyword and I18n translations.

`x-error` is a json_schemer-specific schema keyword that allows overriding error messsages for a schema. It can either be a string, which overrides errors for all keywords (and for the schema itself), or a hash of keyword-specific messages. Interpolation of some values is supported using `gsub` because `sprintf` logs annoying warnings if all arguments aren't present in the string.

I18n translations are enabled when the `i18n` gem is loaded and a `json_schemer` translation key exists. Translation keys are based on schema $id, keyword location, meta-schema $id, and keyword. The lookup is ordered from most specific to least specific so that overrides can be applied as necessary.

Notes:

- Both `x-error` and I18n use special catch-all (`*`) and schema (`^`) "keywords" to support fallbacks and schema-level errors, respectively.
- `x-error` uses the `x-` prefix to match the future spec for unknown keywords: https://github.com/orgs/json-schema-org/discussions/329
- The I18n check to enable translations is cached forever because I18n is slow and I didn't want it to hurt performance when it's not used.
- I18n uses the ASCII unit separator (\x1F) because the `.` default doesn't work well with absolute URIs ($id and $schema).
- I moved `CLASSIC_ERROR_TYPES` out of `JSONSchemer::Result` because that's actually where it's being defined. The `Struct.new` block scope doesn't hold constants like a class.

Closes: https://github.com/davishmcclurg/json_schemer/issues/143