### PR TITLE
Add 'date' format to Openapi 3.0

### DIFF
--- a/lib/json_schemer/openapi30/meta.rb
+++ b/lib/json_schemer/openapi30/meta.rb
@@ -5,7 +5,8 @@ module JSONSchemer
     # https://spec.openapis.org/oas/v3.0.3#data-types
     FORMATS = OpenAPI31::FORMATS.merge(
       'byte' => proc { |instance, _value| Format.decode_content_encoding(instance, 'base64').first },
-      'binary' => proc { |instance, _value| instance.is_a?(String) && instance.encoding == Encoding::ASCII_8BIT }
+      'binary' => proc { |instance, _value| instance.is_a?(String) && instance.encoding == Encoding::ASCII_8BIT },
+      'date' => Format::DATE
     )
     SCHEMA = {
       'id' => 'json-schemer://openapi30/schema',

--- a/test/open_api_test.rb
+++ b/test/open_api_test.rb
@@ -707,7 +707,9 @@ class OpenAPITest < Minitest::Test
         'b' => { 'format' => 'int64' },
         'c' => { 'format' => 'float' },
         'd' => { 'format' => 'double' },
-        'e' => { 'format' => 'password' }
+        'e' => { 'format' => 'password' },
+        'date' => { 'format' => 'date' },
+        'date-time' => { 'format' => 'date-time' }
       }
     }
 
@@ -724,6 +726,8 @@ class OpenAPITest < Minitest::Test
     refute(schemer.valid?({ 'd' => 2 }))
     assert(schemer.valid?({ 'e' => 2 }))
     assert(schemer.valid?({ 'e' => 'anything' }))
+    assert(schemer.valid?({ 'date' => '2023-10-24' }))
+    assert(schemer.valid?({ 'date-time' => '2023-10-24T21:12:18+02:00' }))  
   end
 
   def test_openapi30_formats
@@ -735,7 +739,9 @@ class OpenAPITest < Minitest::Test
         'd' => { 'format' => 'double' },
         'e' => { 'format' => 'password' },
         'f' => { 'format' => 'byte' },
-        'g' => { 'format' => 'binary' }
+        'g' => { 'format' => 'binary' },
+        'date' => { 'format' => 'date' },
+        'date-time' => { 'format' => 'date-time' }
       }
     }
 
@@ -756,6 +762,8 @@ class OpenAPITest < Minitest::Test
     assert(schemer.valid?({ 'f' => 'IQ==' }))
     refute(schemer.valid?({ 'g' => '!' }))
     assert(schemer.valid?({ 'g' => '!'.b }))
+    refute(schemer.valid?({ 'date' => '2023.10.24' }))
+    refute(schemer.valid?({ 'date-time' => '2023-10-24:21:12:18' }))  
   end
 
   def test_unsupported_openapi_version


### PR DESCRIPTION
OpenAPI 3.0 [should support 'date' format](https://spec.openapis.org/oas/v3.0.3#data-types). This change adds that.