### PR TITLE
Drop incorrect `uri-reference` OpenAPI formats

### DIFF
--- a/lib/json_schemer/openapi30/document.rb
+++ b/lib/json_schemer/openapi30/document.rb
@@ -1584,8 +1584,7 @@ module JSONSchemer
                 'type' => 'string'
               },
               'operationRef' => {
-                'type' => 'string',
-                'format' => 'uri-reference'
+                'type' => 'string'
               },
               'parameters' => {
                 'type' => 'object',

--- a/lib/json_schemer/openapi31/document.rb
+++ b/lib/json_schemer/openapi31/document.rb
@@ -270,8 +270,7 @@ module JSONSchemer
             'type' => 'object',
             'properties' => {
               'url' => {
-                'type' => 'string',
-                'format' => 'uri-reference'
+                'type' => 'string'
               },
               'description' => {
                 'type' => 'string'
@@ -1054,8 +1053,7 @@ module JSONSchemer
             'type' => 'object',
             'properties' => {
               'operationRef' => {
-                'type' => 'string',
-                'format' => 'uri-reference'
+                'type' => 'string'
               },
               'operationId' => {
                 'type' => 'string'

--- a/test/json_schemer_test.rb
+++ b/test/json_schemer_test.rb
@@ -435,8 +435,9 @@ class JSONSchemerTest < Minitest::Test
       JSONSchemer::Draft4::SCHEMA,
       JSONSchemer::OpenAPI31::SCHEMA,
       JSONSchemer::OpenAPI31::Meta::BASE,
-      JSONSchemer::OpenAPI31::Document::SCHEMA,
-      JSONSchemer::OpenAPI30::Document::SCHEMA
+      # fixme: https://github.com/OAI/OpenAPI-Specification/pull/3455
+      # JSONSchemer::OpenAPI31::Document::SCHEMA,
+      # JSONSchemer::OpenAPI30::Document::SCHEMA
     ].each do |meta_schema|
       id = meta_schema.key?('$id') ? meta_schema.fetch('$id') : meta_schema.fetch('id')
       assert_equal(meta_schema, JSON.parse(fetch(id)))


### PR DESCRIPTION
Temporary fix until upstream schemas are fixed and published: https://github.com/OAI/OpenAPI-Specification/pull/3455

Closes: https://github.com/davishmcclurg/json_schemer/issues/158