### PR TITLE
Add Ruby 3.3 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        ruby: [2.5, 2.6, 2.7, 3.0, 3.1, 3.2, head, jruby, jruby-head, truffleruby, truffleruby-head]
+        ruby: [2.5, 2.6, 2.7, 3.0, 3.1, 3.2, 3.3, head, jruby, jruby-head, truffleruby, truffleruby-head]
         exclude:
           - os: windows-latest
             ruby: truffleruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,8 @@ PATH
   remote: .
   specs:
     json_schemer (2.1.1)
+      base64
+      bigdecimal
       hana (~> 1.3)
       regexp_parser (~> 2.0)
       simpleidn (~> 0.2)
@@ -9,7 +11,11 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    base64 (0.2.0)
+    bigdecimal (3.1.5)
+    bigdecimal (3.1.5-java)
     concurrent-ruby (1.2.2)
+    csv (3.2.8)
     docile (1.4.0)
     hana (1.3.7)
     i18n (1.14.1)
@@ -17,8 +23,8 @@ GEM
     i18n-debug (1.2.0)
       i18n (< 2)
     minitest (5.15.0)
-    rake (13.0.6)
-    regexp_parser (2.8.2)
+    rake (13.1.0)
+    regexp_parser (2.8.3)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -38,6 +44,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 2.0)
+  csv
   i18n
   i18n-debug
   json_schemer!
@@ -46,4 +53,4 @@ DEPENDENCIES
   simplecov (~> 0.22)
 
 BUNDLED WITH
-   2.3.25
+   2.3.27

--- a/json_schemer.gemspec
+++ b/json_schemer.gemspec
@@ -26,9 +26,12 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "simplecov", "~> 0.22"
+  spec.add_development_dependency "csv"
   spec.add_development_dependency "i18n"
   spec.add_development_dependency "i18n-debug"
 
+  spec.add_runtime_dependency "base64"
+  spec.add_runtime_dependency "bigdecimal"
   spec.add_runtime_dependency "hana", "~> 1.3"
   spec.add_runtime_dependency "regexp_parser", "~> 2.0"
   spec.add_runtime_dependency "simpleidn", "~> 0.2"


### PR DESCRIPTION
And update locked bundler to latest version that supports Ruby 2.5.

I had to add `base64`, `bigdecimal`, and `csv` to the gemspec because Ruby 3.3 now warns that they won't be available in the standard library in Ruby 3.4:

```
/Users/dharsha/repos/json_schemer/lib/json_schemer.rb:2: warning: base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec.
/Users/dharsha/repos/json_schemer/lib/json_schemer.rb:3: warning: bigdecimal was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add bigdecimal to your Gemfile or gemspec.
```

I'm not sure if they need version constraints or not, but I'm going to leave it unset for now.

`minitest` is also triggering a warning, but it looks like it'll be fixed in the next release: https://github.com/minitest/minitest/issues/969