### PR TITLE
Compare property default instance locations by id

### DIFF
--- a/lib/json_schemer/configuration.rb
+++ b/lib/json_schemer/configuration.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 module JSONSchemer
   Configuration = Struct.new(
     :base_uri, :meta_schema, :vocabulary, :format, :formats, :content_encodings, :content_media_types, :keywords,

--- a/lib/json_schemer/result.rb
+++ b/lib/json_schemer/result.rb
@@ -191,6 +191,7 @@ module JSONSchemer
 
     def insert_property_defaults(context)
       instance_locations = {}
+      instance_locations.compare_by_identity
 
       results = [[self, true]]
       while (result, valid = results.pop)


### PR DESCRIPTION
The keys used to collect property defaults are mutable hashes, which
causes weird hash table problems when they're modified (`#hash` no
longer matches even though they have the same `#object_id`).
Explained here: https://docs.ruby-lang.org/en/3.3/Hash.html#class-Hash-label-Modifying+an+Active+Hash+Key

I think this problem got covered up a bit because it requires more than
8 keys for values to be dropped.

`compare_by_identity` fixes things by just using `#object_id` to compare
hash keys. It stays consistent after the hash key is mutated.

From the [docs][0]:

> Note: this requirement does not apply if the Hash uses
> `compare_by_identity` since comparison will then rely on the keys'
> object id instead of `hash` and `eql?`.

Fixes: https://github.com/davishmcclurg/json_schemer/issues/179

[0]: https://docs.ruby-lang.org/en/3.3/Hash.html#class-Hash-label-User-Defined+Hash+Keys