### PR TITLE
Avoid need for Base64 gem at runtime

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     json_schemer (2.2.1)
-      base64
       bigdecimal
       hana (~> 1.3)
       regexp_parser (~> 2.0)
@@ -43,6 +42,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  base64
   bundler (~> 2.0)
   csv
   i18n

--- a/json_schemer.gemspec
+++ b/json_schemer.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.5'
 
+  spec.add_development_dependency "base64"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"
@@ -30,7 +31,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "i18n"
   spec.add_development_dependency "i18n-debug"
 
-  spec.add_runtime_dependency "base64"
   spec.add_runtime_dependency "bigdecimal"
   spec.add_runtime_dependency "hana", "~> 1.3"
   spec.add_runtime_dependency "regexp_parser", "~> 2.0"

--- a/lib/json_schemer.rb
+++ b/lib/json_schemer.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'base64'
 require 'bigdecimal'
 require 'ipaddr'
 require 'json'

--- a/lib/json_schemer/content.rb
+++ b/lib/json_schemer/content.rb
@@ -2,7 +2,7 @@
 module JSONSchemer
   module ContentEncoding
     BASE64 = proc do |instance|
-      [true, Base64.strict_decode64(instance)]
+      [true, instance.unpack1("m0")]
     rescue
       [false, nil]
     end

--- a/test/json_schemer_test.rb
+++ b/test/json_schemer_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'base64'
 require 'csv'
 
 class JSONSchemerTest < Minitest::Test


### PR DESCRIPTION
This follows a common practice that's been adopted by the majority of the Ruby community: https://github.com/rubocop/rubocop/commit/b2b29da6406ed55fe42fe045435c29bed6635299, https://github.com/rack/rack/commit/696ed9e8f48053683a0a19fc68eb49f094c0efcb, https://github.com/lostisland/faraday/commit/9487833b426ad1c50d6d8a29d82601202a528c56, https://github.com/octokit/octokit.rb/commit/a787bf47377229688eea4b6c78b26b584f65595b.

The personal reason for my need for this is that `bootsnap` doesn't seem to work properly on Ruby < 3.4 when using `base64`, which is preventing me from using `json_schemer` 2.2.x:

```
<internal:/ruby/3.3.1/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require': cannot load such file -- /vendor/bundle/ruby/3.3.0/gems/base64-0.2.0/lib/base64.rb (LoadError)
	from <internal:/ruby/3.3.1/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from /vendor/bundle/ruby/3.3.0/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
```

This is technically a Bundler/Bootsnap problem, but I felt it was worthwhile reducing the dependency tree here anyway.