### PR TITLE
fix: Fix nullable ref

### DIFF
--- a/lib/json_schemer/draft202012/vocab/core.rb
+++ b/lib/json_schemer/draft202012/vocab/core.rb
@@ -64,7 +64,11 @@ module JSONSchemer
           end
 
           def validate(instance, instance_location, keyword_location, context)
-            ref_schema.validate_instance(instance, instance_location, keyword_location, context)
+            if instance.nil? && context.dynamic_scope.any? { |x| x.value['nullable'] }
+              result(instance, instance_location, keyword_location, true)
+            else
+              ref_schema.validate_instance(instance, instance_location, keyword_location, context)
+            end
           end
         end
 

--- a/test/open_api_test.rb
+++ b/test/open_api_test.rb
@@ -1094,4 +1094,28 @@ class OpenAPITest < Minitest::Test
     assert(document.valid?)
     assert(schemer.valid_schema?)
   end
+
+  def test_nullable_ref
+    schemer = JSONSchemer.openapi({
+      'openapi' => '3.0.0',
+      'components' => {
+        'schemas' => {
+          'test' => {
+            'nullable' => true,
+            '$ref' => '#/components/schemas/nullable_schema'
+          },
+          'nullable_schema' => {
+            'type' => 'object',
+            'properties' => {
+              'a' => { 'type' => 'string' },
+            }
+          }
+        }
+      }
+    }).schema('test')
+
+    assert(schemer.valid_schema?)
+    assert(schemer.valid?({ 'a' => 'test' }))
+    assert(schemer.valid?(nil))
+  end
 end


### PR DESCRIPTION
This pull request includes changes to enhance the handling of nullable references in the JSON Schemer library. The main updates involve adding a check for nullable references in the validation process and introducing a new test case to ensure the functionality works as expected.

Enhancements to nullable reference handling:

* [`lib/json_schemer/draft202012/vocab/core.rb`](diffhunk://#diff-d21dc91f58e6f3eefa30b6aa292c82a68ee2a2d7dc205198856dd20790a89a7dR67-R73): Updated the `validate` method to check if the instance is `nil` and if any dynamic scope contains a `nullable` value, returning a successful result in such cases.

Testing improvements:

* [`test/open_api_test.rb`](diffhunk://#diff-eb7dbffc8e3907271e3cfbb09e99511d26afbb636c70b6be6a4178575e526480R1097-R1120): Added a new test case `test_nullable_ref` to validate schemas with nullable references, ensuring they are correctly recognized and validated by the schemer.