### PR TITLE
Require discriminator instance to be an object

### DIFF
--- a/lib/json_schemer/openapi31/vocab/base.rb
+++ b/lib/json_schemer/openapi31/vocab/base.rb
@@ -100,7 +100,7 @@ module JSONSchemer
           end
 
           def validate(instance, instance_location, keyword_location, context)
-            return result(instance, instance_location, keyword_location, true) unless instance.is_a?(Hash)
+            return result(instance, instance_location, keyword_location, false) unless instance.is_a?(Hash)
 
             property_name = value.fetch('propertyName')
 


### PR DESCRIPTION
Previously, all non-hash instances were valid when using `discriminator`, which I think is incorrect and confusing. There are a couple options:

1. Require instances to be objects when using `discriminator`
2. Fall back to regular `allOf`/`anyOf`/`oneOf` processing for non-object instances

I went with option 1, because it seems safer and I don't know if it makes sense to ever allow non-object instances. `discriminator` depends on `propertyName`, which itself requires hash instances. Allowing `null` is still possible by wrapping the `discriminator` schema in another `oneOf` (like the test example: `nullable_union_schema`).

The [OpenAPI specification][0] doesn't say anything about non-object instances directly, but it does say:

> The expectation now is that a property with name petType MUST be present in the response payload, and the value will correspond to the name of a schema defined in the OAS document.

Which I think can be interpreted as requiring the response payload to be an object.

Fixes: https://github.com/davishmcclurg/json_schemer/issues/204
Related: https://github.com/davishmcclurg/json_schemer/commit/be45f04e515df7da9eb0d9694bf3b1db3a7fbfdd

[0]: https://github.com/oai/openapi-specification/blob/main/versions/3.1.0.md#discriminator-object