### PR TITLE
Ruby 3.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        ruby: [2.7, 3.0, 3.1, 3.2, 3.3, head, jruby, jruby-head, truffleruby, truffleruby-head]
+        ruby: [2.7, 3.0, 3.1, 3.2, 3.3, 3.4, head, jruby, jruby-head, truffleruby, truffleruby-head]
         exclude:
           - os: ubuntu-latest
             ruby: head

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,24 +11,24 @@ GEM
   remote: https://rubygems.org/
   specs:
     base64 (0.2.0)
-    bigdecimal (3.1.8)
-    bigdecimal (3.1.8-java)
-    concurrent-ruby (1.2.2)
-    csv (3.2.8)
-    docile (1.4.0)
+    bigdecimal (3.1.9)
+    bigdecimal (3.1.9-java)
+    concurrent-ruby (1.3.5)
+    csv (3.3.2)
+    docile (1.4.1)
     hana (1.3.7)
-    i18n (1.14.1)
+    i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     i18n-debug (1.2.0)
       i18n (< 2)
-    minitest (5.15.0)
-    rake (13.1.0)
-    regexp_parser (2.9.2)
+    minitest (5.25.4)
+    rake (13.2.1)
+    regexp_parser (2.10.0)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
-    simplecov-html (0.12.3)
+    simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
     simpleidn (0.2.3)
 
@@ -38,7 +38,7 @@ PLATFORMS
 
 DEPENDENCIES
   base64
-  bundler (~> 2.0)
+  bundler (~> 2.4.0)
   csv
   i18n
   i18n-debug
@@ -48,4 +48,4 @@ DEPENDENCIES
   simplecov (~> 0.22)
 
 BUNDLED WITH
-   2.3.27
+   2.4.22

--- a/json_schemer.gemspec
+++ b/json_schemer.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.7'
 
   spec.add_development_dependency "base64"
-  spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_development_dependency "bundler", "~> 2.4.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "simplecov", "~> 0.22"

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class ConfigurationTest < Minitest::Test
-  def run_configuration_test(option, default: (skip_default = true), test:)
+  def run_configuration_test(option, test:, default: (skip_default = true))
     original = JSONSchemer.configuration.public_send(option)
 
     if default.nil?


### PR DESCRIPTION
- Stay on Bundler 2.4 for Ruby 2.7 support
- Upgrade gems to get around default/bundled gems errors (eg, `'Kernel#require': cannot load such file -- mutex_m (LoadError)` from minitest)
- Change keyword argument order for JRuby: https://github.com/jruby/jruby/issues/8577
- Hack around `Hash#inspect` [changes][0] (space around `=>`) in tests

[0]: https://rubyreferences.github.io/rubychanges/3.4.html#inspect-rendering-have-been-changed