### PR TITLE
Merge configuration options to pass to subschemas

### DIFF
--- a/lib/json_schemer.rb
+++ b/lib/json_schemer.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'bigdecimal'
+require 'forwardable'
 require 'ipaddr'
 require 'json'
 require 'net/http'


### PR DESCRIPTION
This effectively merges `Schema.new` options with the provided `Configuration` object (or the default global one) so that subschemas validate using the same configuration as the parent schema.

`base_uri` and `meta_schema` are still instance variables because they're modified by keywords (that's why they're `attr_accessor`).

`resolve_ref` still passes `ref_resolver` and `regexp_resolver` to subschemas to support caching (because the `CachedResolver` instances are created in `Schema`). They could maybe be cached in `Configuration` instead, but that felt like a bigger change.

Fixes: https://github.com/davishmcclurg/json_schemer/issues/198