### PR TITLE
Support nullable `format`s for Openapi

### DIFF
--- a/lib/json_schemer/openapi30/meta.rb
+++ b/lib/json_schemer/openapi30/meta.rb
@@ -4,8 +4,8 @@ module JSONSchemer
     BASE_URI = URI('json-schemer://openapi30/schema')
     # https://spec.openapis.org/oas/v3.0.3#data-types
     FORMATS = OpenAPI31::FORMATS.merge(
-      'byte' => proc { |instance, _value| ContentEncoding::BASE64.call(instance).first },
-      'binary' => proc { |instance, _value| instance.is_a?(String) && instance.encoding == Encoding::BINARY },
+      'byte' => proc { |instance, _value| !instance.is_a?(String) || ContentEncoding::BASE64.call(instance).first },
+      'binary' => proc { |instance, _value| !instance.is_a?(String) || instance.encoding == Encoding::BINARY },
       'date' => Format::DATE
     )
     SCHEMA = {

--- a/lib/json_schemer/openapi30/meta.rb
+++ b/lib/json_schemer/openapi30/meta.rb
@@ -4,6 +4,8 @@ module JSONSchemer
     BASE_URI = URI('json-schemer://openapi30/schema')
     # https://spec.openapis.org/oas/v3.0.3#data-types
     FORMATS = OpenAPI31::FORMATS.merge(
+      'int32' => proc { |instance, _format| !instance.is_a?(Integer) || instance.floor.bit_length <= 32 },
+      'int64' => proc { |instance, _format| !instance.is_a?(Integer) || instance.floor.bit_length <= 64 },
       'byte' => proc { |instance, _value| !instance.is_a?(String) || ContentEncoding::BASE64.call(instance).first },
       'binary' => proc { |instance, _value| !instance.is_a?(String) || instance.encoding == Encoding::BINARY },
       'date' => Format::DATE

--- a/lib/json_schemer/openapi31/meta.rb
+++ b/lib/json_schemer/openapi31/meta.rb
@@ -4,8 +4,8 @@ module JSONSchemer
     BASE_URI = URI('https://spec.openapis.org/oas/3.1/dialect/base')
     # https://spec.openapis.org/oas/v3.1.0#data-types
     FORMATS = {
-      'int32' => proc { |instance, _format| instance.nil? || (instance.is_a?(Integer) && instance.bit_length <= 32) },
-      'int64' => proc { |instance, _format| instance.nil? || (instance.is_a?(Integer) && instance.bit_length <= 64) },
+      'int32' => proc { |instance, _format| !instance.is_a?(Integer) || instance.bit_length <= 32 },
+      'int64' => proc { |instance, _format| !instance.is_a?(Integer) || instance.bit_length <= 64 },
       'float' => proc { |instance, _format| instance.nil? || instance.is_a?(Float) },
       'double' => proc { |instance, _format| instance.nil? || instance.is_a?(Float) },
       'password' => proc { |_instance, _format| true }

--- a/lib/json_schemer/openapi31/meta.rb
+++ b/lib/json_schemer/openapi31/meta.rb
@@ -4,8 +4,14 @@ module JSONSchemer
     BASE_URI = URI('https://spec.openapis.org/oas/3.1/dialect/base')
     # https://spec.openapis.org/oas/v3.1.0#data-types
     FORMATS = {
-      'int32' => proc { |instance, _format| !instance.is_a?(Integer) || instance.bit_length <= 32 },
-      'int64' => proc { |instance, _format| !instance.is_a?(Integer) || instance.bit_length <= 64 },
+      'int32' => proc do |instance, _format|
+        valid_type = instance.is_a?(Numeric) && (instance.is_a?(Integer) || instance.floor == instance)
+        !valid_type || instance.floor.bit_length <= 32
+      end,
+      'int64' => proc do |instance, _format|
+        valid_type = instance.is_a?(Numeric) && (instance.is_a?(Integer) || instance.floor == instance)
+        !valid_type || instance.floor.bit_length <= 64
+      end,
       'float' => proc { |instance, _format| !instance.is_a?(Numeric) || instance.is_a?(Float) },
       'double' => proc { |instance, _format| !instance.is_a?(Numeric) || instance.is_a?(Float) },
       'password' => proc { |_instance, _format| true }

--- a/lib/json_schemer/openapi31/meta.rb
+++ b/lib/json_schemer/openapi31/meta.rb
@@ -6,8 +6,8 @@ module JSONSchemer
     FORMATS = {
       'int32' => proc { |instance, _format| !instance.is_a?(Integer) || instance.bit_length <= 32 },
       'int64' => proc { |instance, _format| !instance.is_a?(Integer) || instance.bit_length <= 64 },
-      'float' => proc { |instance, _format| instance.nil? || instance.is_a?(Float) },
-      'double' => proc { |instance, _format| instance.nil? || instance.is_a?(Float) },
+      'float' => proc { |instance, _format| !instance.is_a?(Numeric) || instance.is_a?(Float) },
+      'double' => proc { |instance, _format| !instance.is_a?(Numeric) || instance.is_a?(Float) },
       'password' => proc { |_instance, _format| true }
     }
     SCHEMA = {

--- a/lib/json_schemer/openapi31/meta.rb
+++ b/lib/json_schemer/openapi31/meta.rb
@@ -4,10 +4,10 @@ module JSONSchemer
     BASE_URI = URI('https://spec.openapis.org/oas/3.1/dialect/base')
     # https://spec.openapis.org/oas/v3.1.0#data-types
     FORMATS = {
-      'int32' => proc { |instance, _format| instance.is_a?(Integer) && instance.bit_length <= 32 },
-      'int64' => proc { |instance, _format| instance.is_a?(Integer) && instance.bit_length <= 64 },
-      'float' => proc { |instance, _format| instance.is_a?(Float) },
-      'double' => proc { |instance, _format| instance.is_a?(Float) },
+      'int32' => proc { |instance, _format| instance.nil? || (instance.is_a?(Integer) && instance.bit_length <= 32) },
+      'int64' => proc { |instance, _format| instance.nil? || (instance.is_a?(Integer) && instance.bit_length <= 64) },
+      'float' => proc { |instance, _format| instance.nil? || instance.is_a?(Float) },
+      'double' => proc { |instance, _format| instance.nil? || instance.is_a?(Float) },
       'password' => proc { |_instance, _format| true }
     }
     SCHEMA = {

--- a/test/open_api_test.rb
+++ b/test/open_api_test.rb
@@ -780,8 +780,8 @@ class OpenAPITest < Minitest::Test
         'e' => { 'type' => 'string', 'format' => 'password' },
         'f' => { 'type' => 'string', 'format' => 'byte' },
         'g' => { 'type' => 'string', 'format' => 'binary' },
-        'h' => { 'format' => 'date' },
-        'i' => { 'format' => 'date-time' }
+        'h' => { 'type' => 'string', 'format' => 'date' },
+        'i' => { 'type' => 'string', 'format' => 'date-time' }
       }
     }
 
@@ -810,10 +810,12 @@ class OpenAPITest < Minitest::Test
     assert(schemer.valid?({ 'g' => '!'.b }))
     refute(schemer.valid?({ 'g' => '!' }))
     refute(schemer.valid?({ 'g' => 123 }))
-    refute(schemer.valid?({ 'h' => '2001-02-03T04:05:06.123456789+07:00' }))
     assert(schemer.valid?({ 'h' => '2001-02-03' }))
-    refute(schemer.valid?({ 'i' => '2001-02-03' }))
+    refute(schemer.valid?({ 'h' => '2001-02-03T04:05:06.123456789+07:00' }))
+    refute(schemer.valid?({ 'h' => 123 }))
     assert(schemer.valid?({ 'i' => '2001-02-03T04:05:06.123456789+07:00' }))
+    refute(schemer.valid?({ 'i' => '2001-02-03' }))
+    refute(schemer.valid?({ 'i' => 123 }))
   end
 
   def test_openapi30_nullable_formats
@@ -825,7 +827,9 @@ class OpenAPITest < Minitest::Test
         'd' => { 'type' => 'number', 'format' => 'double', 'nullable' => true },
         'e' => { 'type' => 'string', 'format' => 'password', 'nullable' => true },
         'f' => { 'type' => 'string', 'format' => 'byte', 'nullable' => true },
-        'g' => { 'type' => 'string', 'format' => 'binary', 'nullable' => true }
+        'g' => { 'type' => 'string', 'format' => 'binary', 'nullable' => true },
+        'h' => { 'type' => 'string', 'format' => 'date', 'nullable' => true },
+        'i' => { 'type' => 'string', 'format' => 'date-time', 'nullable' => true }
       }
     }
 
@@ -850,11 +854,15 @@ class OpenAPITest < Minitest::Test
     assert(schemer.valid?({ 'f' => 'IQ==' }))
     assert(schemer.valid?({ 'f' => nil }))
     refute(schemer.valid?({ 'f' => '!' }))
-    refute(schemer.valid?({ 'f' => 123 }))
     assert(schemer.valid?({ 'g' => '!'.b }))
     assert(schemer.valid?({ 'g' => nil }))
     refute(schemer.valid?({ 'g' => '!' }))
-    refute(schemer.valid?({ 'g' => 123 }))
+    assert(schemer.valid?({ 'h' => '2001-02-03' }))
+    assert(schemer.valid?({ 'h' => nil }))
+    refute(schemer.valid?({ 'h' => '2001-02-03T04:05:06.123456789+07:00' }))
+    assert(schemer.valid?({ 'i' => '2001-02-03T04:05:06.123456789+07:00' }))
+    assert(schemer.valid?({ 'i' => nil }))
+    refute(schemer.valid?({ 'i' => '2001-02-03' }))
   end
 
   def test_unsupported_openapi_version

--- a/test/open_api_test.rb
+++ b/test/open_api_test.rb
@@ -703,6 +703,45 @@ class OpenAPITest < Minitest::Test
   def test_openapi31_formats
     schema = {
       'properties' => {
+        'a' => { 'format' => 'int32' },
+        'b' => { 'format' => 'int64' },
+        'c' => { 'format' => 'float' },
+        'd' => { 'format' => 'double' },
+        'e' => { 'format' => 'password' }
+      }
+    }
+
+    schemer = JSONSchemer.schema(schema, :meta_schema => JSONSchemer.openapi31)
+
+    assert(schemer.valid_schema?)
+    # int32
+    assert(schemer.valid?({ 'a' => 2.pow(31) }))
+    assert(schemer.valid?({ 'a' => 2.pow(31).to_f }))
+    assert(schemer.valid?({ 'a' => 2.pow(31).to_s }))
+    refute(schemer.valid?({ 'a' => 2.pow(32) }))
+    refute(schemer.valid?({ 'a' => 2.pow(32).to_f }))
+    # int64
+    assert(schemer.valid?({ 'b' => 2.pow(63) }))
+    assert(schemer.valid?({ 'b' => 2.pow(63).to_f }))
+    assert(schemer.valid?({ 'a' => 2.pow(63).to_s }))
+    refute(schemer.valid?({ 'b' => 2.pow(64) }))
+    refute(schemer.valid?({ 'b' => 2.pow(64).to_f }))
+    # float
+    assert(schemer.valid?({ 'c' => 2.0 }))
+    assert(schemer.valid?({ 'c' => 2.to_s }))
+    refute(schemer.valid?({ 'c' => 2 }))
+    # double
+    assert(schemer.valid?({ 'd' => 2.0 }))
+    assert(schemer.valid?({ 'd' => 2.to_s }))
+    refute(schemer.valid?({ 'd' => 2 }))
+    # password
+    assert(schemer.valid?({ 'e' => 'anything' }))
+    assert(schemer.valid?({ 'e' => 2 }))
+  end
+
+  def test_openapi31_formats_with_type
+    schema = {
+      'properties' => {
         'a' => { 'type' => 'integer', 'format' => 'int32' },
         'b' => { 'type' => 'integer', 'format' => 'int64' },
         'c' => { 'type' => 'number', 'format' => 'float' },
@@ -714,63 +753,123 @@ class OpenAPITest < Minitest::Test
     schemer = JSONSchemer.schema(schema, :meta_schema => JSONSchemer.openapi31)
 
     assert(schemer.valid_schema?)
+    # int32
     assert(schemer.valid?({ 'a' => 2.pow(31) }))
     assert(schemer.valid?({ 'a' => 2.pow(31).to_f }))
-    refute(schemer.valid?({ 'a' => 2.pow(31).to_s }))
     refute(schemer.valid?({ 'a' => 2.pow(32) }))
-    refute(schemer.valid?({ 'a' => 123.123 }))
+    refute(schemer.valid?({ 'a' => 2.pow(32).to_f }))
+    # int64
     assert(schemer.valid?({ 'b' => 2.pow(63) }))
     assert(schemer.valid?({ 'b' => 2.pow(63).to_f }))
-    refute(schemer.valid?({ 'a' => 2.pow(63).to_s }))
     refute(schemer.valid?({ 'b' => 2.pow(64) }))
-    refute(schemer.valid?({ 'b' => 123.123 }))
+    refute(schemer.valid?({ 'b' => 2.pow(64).to_f }))
+    # float
     assert(schemer.valid?({ 'c' => 2.0 }))
     refute(schemer.valid?({ 'c' => 2 }))
-    refute(schemer.valid?({ 'c' => 2.to_s }))
+    # double
     assert(schemer.valid?({ 'd' => 2.0 }))
     refute(schemer.valid?({ 'd' => 2 }))
-    refute(schemer.valid?({ 'd' => 2.to_s }))
+    # password
     assert(schemer.valid?({ 'e' => 'anything' }))
     refute(schemer.valid?({ 'e' => 2 }))
   end
 
-  def test_openapi31_formats_multiple_types
+  def test_openapi31_formats_with_multiple_types
     schema = {
       'properties' => {
-        'a' => { 'type' => ['integer', 'boolean', 'null'], 'format' => 'int32' },
-        'b' => { 'type' => ['integer', 'boolean', 'null'], 'format' => 'int64' },
-        'c' => { 'type' => ['number', 'boolean', 'null'], 'format' => 'float' },
-        'd' => { 'type' => ['number', 'boolean', 'null'], 'format' => 'double' },
-        'e' => { 'type' => ['string', 'boolean', 'null'], 'format' => 'password' }
+        'a' => { 'type' => ['integer', 'null'], 'format' => 'int32' },
+        'b' => { 'type' => ['integer', 'null'], 'format' => 'int64' },
+        'c' => { 'type' => ['number', 'null'], 'format' => 'float' },
+        'd' => { 'type' => ['number', 'null'], 'format' => 'double' },
+        'e' => { 'type' => ['string', 'null'], 'format' => 'password' }
       }
     }
 
     schemer = JSONSchemer.schema(schema, :meta_schema => JSONSchemer.openapi31)
 
     assert(schemer.valid_schema?)
+    # int32
     assert(schemer.valid?({ 'a' => 2.pow(31) }))
-    assert(schemer.valid?({ 'a' => true }))
     assert(schemer.valid?({ 'a' => nil }))
     refute(schemer.valid?({ 'a' => 2.pow(32) }))
+    # int64
     assert(schemer.valid?({ 'b' => 2.pow(63) }))
-    assert(schemer.valid?({ 'b' => true }))
     assert(schemer.valid?({ 'b' => nil }))
     refute(schemer.valid?({ 'b' => 2.pow(64) }))
+    # float
     assert(schemer.valid?({ 'c' => 2.0 }))
-    assert(schemer.valid?({ 'c' => true }))
     assert(schemer.valid?({ 'c' => nil }))
     refute(schemer.valid?({ 'c' => 2 }))
+    # double
     assert(schemer.valid?({ 'd' => 2.0 }))
-    assert(schemer.valid?({ 'd' => true }))
     assert(schemer.valid?({ 'd' => nil }))
     refute(schemer.valid?({ 'd' => 2 }))
+    # password
     assert(schemer.valid?({ 'e' => 'anything' }))
-    assert(schemer.valid?({ 'e' => true }))
     assert(schemer.valid?({ 'e' => nil }))
     refute(schemer.valid?({ 'e' => 2 }))
   end
 
   def test_openapi30_formats
+    schema = {
+      'properties' => {
+        'a' => { 'format' => 'int32' },
+        'b' => { 'format' => 'int64' },
+        'c' => { 'format' => 'float' },
+        'd' => { 'format' => 'double' },
+        'e' => { 'format' => 'password' },
+        'f' => { 'format' => 'byte' },
+        'g' => { 'format' => 'binary' },
+        'h' => { 'format' => 'date' },
+        'i' => { 'format' => 'date-time' }
+      }
+    }
+
+    schemer = JSONSchemer.schema(schema, :meta_schema => JSONSchemer.openapi30)
+
+    assert(schemer.valid_schema?)
+    # int32
+    assert(schemer.valid?({ 'a' => 2.pow(31) }))
+    assert(schemer.valid?({ 'a' => 2.pow(31).to_f }))
+    assert(schemer.valid?({ 'a' => 2.pow(31).to_s }))
+    assert(schemer.valid?({ 'a' => 2.pow(32).to_f }))
+    refute(schemer.valid?({ 'a' => 2.pow(32) }))
+    # int64
+    assert(schemer.valid?({ 'b' => 2.pow(63) }))
+    assert(schemer.valid?({ 'b' => 2.pow(63).to_f }))
+    assert(schemer.valid?({ 'a' => 2.pow(63).to_s }))
+    assert(schemer.valid?({ 'b' => 2.pow(64).to_f }))
+    refute(schemer.valid?({ 'b' => 2.pow(64) }))
+    # float
+    assert(schemer.valid?({ 'c' => 2.0 }))
+    assert(schemer.valid?({ 'c' => 2.to_s }))
+    refute(schemer.valid?({ 'c' => 2 }))
+    # double
+    assert(schemer.valid?({ 'd' => 2.0 }))
+    assert(schemer.valid?({ 'd' => 2.to_s }))
+    refute(schemer.valid?({ 'd' => 2 }))
+    # password
+    assert(schemer.valid?({ 'e' => 'anything' }))
+    assert(schemer.valid?({ 'e' => 2 }))
+    # byte
+    assert(schemer.valid?({ 'f' => 'IQ==' }))
+    assert(schemer.valid?({ 'f' => 123 }))
+    refute(schemer.valid?({ 'f' => '!' }))
+    # binary
+    assert(schemer.valid?({ 'g' => '!'.b }))
+    assert(schemer.valid?({ 'g' => 123 }))
+    refute(schemer.valid?({ 'g' => '!' }))
+    # date
+    assert(schemer.valid?({ 'h' => '2001-02-03' }))
+    assert(schemer.valid?({ 'h' => 123 }))
+    refute(schemer.valid?({ 'h' => '2001-02-03T04:05:06.123456789+07:00' }))
+    # date-time
+    assert(schemer.valid?({ 'i' => '2001-02-03T04:05:06.123456789+07:00' }))
+    assert(schemer.valid?({ 'i' => 123 }))
+    refute(schemer.valid?({ 'i' => '2001-02-03' }))
+  end
+
+  def test_openapi30_formats_with_type
     schema = {
       'properties' => {
         'a' => { 'type' => 'integer', 'format' => 'int32' },
@@ -788,31 +887,40 @@ class OpenAPITest < Minitest::Test
     schemer = JSONSchemer.schema(schema, :meta_schema => JSONSchemer.openapi30)
 
     assert(schemer.valid_schema?)
+    # int32
     assert(schemer.valid?({ 'a' => 2.pow(31) }))
     refute(schemer.valid?({ 'a' => 2.pow(31).to_s }))
     refute(schemer.valid?({ 'a' => 2.pow(32) }))
-    refute(schemer.valid?({ 'a' => 123.123 }))
+    refute(schemer.valid?({ 'a' => 2.pow(32).to_f }))
+    # int64
     assert(schemer.valid?({ 'b' => 2.pow(63) }))
     refute(schemer.valid?({ 'a' => 2.pow(63).to_s }))
     refute(schemer.valid?({ 'b' => 2.pow(64) }))
-    refute(schemer.valid?({ 'b' => 123.123 }))
+    refute(schemer.valid?({ 'b' => 2.pow(64).to_f }))
+    # float
     assert(schemer.valid?({ 'c' => 2.0 }))
     refute(schemer.valid?({ 'c' => 2 }))
     refute(schemer.valid?({ 'c' => 2.to_s }))
+    # double
     assert(schemer.valid?({ 'd' => 2.0 }))
     refute(schemer.valid?({ 'd' => 2 }))
     refute(schemer.valid?({ 'd' => 2.to_s }))
+    # password
     assert(schemer.valid?({ 'e' => 'anything' }))
     refute(schemer.valid?({ 'e' => 2 }))
+    # byte
     assert(schemer.valid?({ 'f' => 'IQ==' }))
     refute(schemer.valid?({ 'f' => '!' }))
     refute(schemer.valid?({ 'f' => 123 }))
+    # binary
     assert(schemer.valid?({ 'g' => '!'.b }))
     refute(schemer.valid?({ 'g' => '!' }))
     refute(schemer.valid?({ 'g' => 123 }))
+    # date
     assert(schemer.valid?({ 'h' => '2001-02-03' }))
     refute(schemer.valid?({ 'h' => '2001-02-03T04:05:06.123456789+07:00' }))
     refute(schemer.valid?({ 'h' => 123 }))
+    # date-time
     assert(schemer.valid?({ 'i' => '2001-02-03T04:05:06.123456789+07:00' }))
     refute(schemer.valid?({ 'i' => '2001-02-03' }))
     refute(schemer.valid?({ 'i' => 123 }))
@@ -836,30 +944,39 @@ class OpenAPITest < Minitest::Test
     schemer = JSONSchemer.schema(schema, :meta_schema => JSONSchemer.openapi30)
 
     assert(schemer.valid_schema?)
+    # int32
     assert(schemer.valid?({ 'a' => 2.pow(31) }))
     assert(schemer.valid?({ 'a' => nil }))
     refute(schemer.valid?({ 'a' => 2.pow(32) }))
+    # int64
     assert(schemer.valid?({ 'b' => 2.pow(63) }))
     assert(schemer.valid?({ 'b' => nil }))
     refute(schemer.valid?({ 'b' => 2.pow(64) }))
+    # float
     assert(schemer.valid?({ 'c' => 2.0 }))
     assert(schemer.valid?({ 'c' => nil }))
     refute(schemer.valid?({ 'c' => 2 }))
+    # double
     assert(schemer.valid?({ 'd' => 2.0 }))
     assert(schemer.valid?({ 'd' => nil }))
     refute(schemer.valid?({ 'd' => 2 }))
+    # password
     assert(schemer.valid?({ 'e' => 'anything' }))
     assert(schemer.valid?({ 'e' => nil }))
     refute(schemer.valid?({ 'e' => 2 }))
+    # byte
     assert(schemer.valid?({ 'f' => 'IQ==' }))
     assert(schemer.valid?({ 'f' => nil }))
     refute(schemer.valid?({ 'f' => '!' }))
+    # binary
     assert(schemer.valid?({ 'g' => '!'.b }))
     assert(schemer.valid?({ 'g' => nil }))
     refute(schemer.valid?({ 'g' => '!' }))
+    # date
     assert(schemer.valid?({ 'h' => '2001-02-03' }))
     assert(schemer.valid?({ 'h' => nil }))
     refute(schemer.valid?({ 'h' => '2001-02-03T04:05:06.123456789+07:00' }))
+    # date-time
     assert(schemer.valid?({ 'i' => '2001-02-03T04:05:06.123456789+07:00' }))
     assert(schemer.valid?({ 'i' => nil }))
     refute(schemer.valid?({ 'i' => '2001-02-03' }))

--- a/test/open_api_test.rb
+++ b/test/open_api_test.rb
@@ -715,28 +715,30 @@ class OpenAPITest < Minitest::Test
 
     assert(schemer.valid_schema?)
     assert(schemer.valid?({ 'a' => 2.pow(31) }))
+    assert(schemer.valid?({ 'a' => 2.pow(31).to_f }))
+    refute(schemer.valid?({ 'a' => 2.pow(31).to_s }))
     refute(schemer.valid?({ 'a' => 2.pow(32) }))
-    refute(schemer.valid?({ 'a' => nil }))
+    refute(schemer.valid?({ 'a' => 123.123 }))
     assert(schemer.valid?({ 'b' => 2.pow(63) }))
+    assert(schemer.valid?({ 'b' => 2.pow(63).to_f }))
+    refute(schemer.valid?({ 'a' => 2.pow(63).to_s }))
     refute(schemer.valid?({ 'b' => 2.pow(64) }))
-    refute(schemer.valid?({ 'b' => nil }))
+    refute(schemer.valid?({ 'b' => 123.123 }))
     assert(schemer.valid?({ 'c' => 2.0 }))
     refute(schemer.valid?({ 'c' => 2 }))
-    refute(schemer.valid?({ 'c' => nil }))
     assert(schemer.valid?({ 'd' => 2.0 }))
     refute(schemer.valid?({ 'd' => 2 }))
-    refute(schemer.valid?({ 'd' => nil }))
     assert(schemer.valid?({ 'e' => 2 }))
     assert(schemer.valid?({ 'e' => 'anything' }))
   end
 
-  def test_openapi31_nullable_formats
+  def test_openapi31_formats_multiple_types
     schema = {
       'properties' => {
-        'a' => { 'type' => ['integer', 'null'], 'format' => 'int32' },
-        'b' => { 'type' => ['integer', 'null'], 'format' => 'int64' },
+        'a' => { 'type' => ['integer', 'boolean', 'null'], 'format' => 'int32' },
+        'b' => { 'type' => ['integer', 'boolean', 'null'], 'format' => 'int64' },
         'c' => { 'type' => ['number', 'null'], 'format' => 'float' },
-        'd' => { 'type' => ['number', 'null'], 'format' => 'double' },
+        'd' => { 'type' => ['number', 'null'], 'format' => 'double' }
       }
     }
 
@@ -744,9 +746,11 @@ class OpenAPITest < Minitest::Test
 
     assert(schemer.valid_schema?)
     assert(schemer.valid?({ 'a' => 2.pow(31) }))
+    assert(schemer.valid?({ 'a' => true }))
     assert(schemer.valid?({ 'a' => nil }))
     refute(schemer.valid?({ 'a' => 2.pow(32) }))
     assert(schemer.valid?({ 'b' => 2.pow(63) }))
+    assert(schemer.valid?({ 'b' => true }))
     assert(schemer.valid?({ 'b' => nil }))
     refute(schemer.valid?({ 'b' => 2.pow(64) }))
     assert(schemer.valid?({ 'c' => 2.0 }))
@@ -776,11 +780,13 @@ class OpenAPITest < Minitest::Test
 
     assert(schemer.valid_schema?)
     assert(schemer.valid?({ 'a' => 2.pow(31) }))
+    refute(schemer.valid?({ 'a' => 2.pow(31).to_s }))
     refute(schemer.valid?({ 'a' => 2.pow(32) }))
-    refute(schemer.valid?({ 'a' => nil }))
+    refute(schemer.valid?({ 'a' => 123.123 }))
     assert(schemer.valid?({ 'b' => 2.pow(63) }))
+    refute(schemer.valid?({ 'a' => 2.pow(63).to_s }))
     refute(schemer.valid?({ 'b' => 2.pow(64) }))
-    refute(schemer.valid?({ 'b' => nil }))
+    refute(schemer.valid?({ 'b' => 123.123 }))
     assert(schemer.valid?({ 'c' => 2.0 }))
     refute(schemer.valid?({ 'c' => 2 }))
     refute(schemer.valid?({ 'c' => nil }))
@@ -805,7 +811,7 @@ class OpenAPITest < Minitest::Test
         'a' => { 'type' => 'integer', 'format' => 'int32', 'nullable' => true },
         'b' => { 'type' => 'integer', 'format' => 'int64', 'nullable' => true },
         'c' => { 'type' => 'number', 'format' => 'float', 'nullable' => true },
-        'd' => { 'type' => 'number', 'format' => 'double', 'nullable' => true },
+        'd' => { 'type' => 'number', 'format' => 'double', 'nullable' => true }
       }
     }
 

--- a/test/open_api_test.rb
+++ b/test/open_api_test.rb
@@ -703,10 +703,10 @@ class OpenAPITest < Minitest::Test
   def test_openapi31_formats
     schema = {
       'properties' => {
-        'a' => { 'format' => 'int32' },
-        'b' => { 'format' => 'int64' },
-        'c' => { 'format' => 'float' },
-        'd' => { 'format' => 'double' },
+        'a' => { 'type' => 'integer', 'format' => 'int32' },
+        'b' => { 'type' => 'integer', 'format' => 'int64' },
+        'c' => { 'type' => 'number', 'format' => 'float' },
+        'd' => { 'type' => 'number', 'format' => 'double' },
         'e' => { 'format' => 'password' }
       }
     }
@@ -716,23 +716,54 @@ class OpenAPITest < Minitest::Test
     assert(schemer.valid_schema?)
     assert(schemer.valid?({ 'a' => 2.pow(31) }))
     refute(schemer.valid?({ 'a' => 2.pow(32) }))
+    refute(schemer.valid?({ 'a' => nil }))
     assert(schemer.valid?({ 'b' => 2.pow(63) }))
     refute(schemer.valid?({ 'b' => 2.pow(64) }))
+    refute(schemer.valid?({ 'b' => nil }))
     assert(schemer.valid?({ 'c' => 2.0 }))
     refute(schemer.valid?({ 'c' => 2 }))
+    refute(schemer.valid?({ 'c' => nil }))
     assert(schemer.valid?({ 'd' => 2.0 }))
     refute(schemer.valid?({ 'd' => 2 }))
+    refute(schemer.valid?({ 'd' => nil }))
     assert(schemer.valid?({ 'e' => 2 }))
     assert(schemer.valid?({ 'e' => 'anything' }))
+  end
+
+  def test_openapi31_nullable_formats
+    schema = {
+      'properties' => {
+        'a' => { 'type' => ['integer', 'null'], 'format' => 'int32' },
+        'b' => { 'type' => ['integer', 'null'], 'format' => 'int64' },
+        'c' => { 'type' => ['number', 'null'], 'format' => 'float' },
+        'd' => { 'type' => ['number', 'null'], 'format' => 'double' },
+      }
+    }
+
+    schemer = JSONSchemer.schema(schema, :meta_schema => JSONSchemer.openapi31)
+
+    assert(schemer.valid_schema?)
+    assert(schemer.valid?({ 'a' => 2.pow(31) }))
+    assert(schemer.valid?({ 'a' => nil }))
+    refute(schemer.valid?({ 'a' => 2.pow(32) }))
+    assert(schemer.valid?({ 'b' => 2.pow(63) }))
+    assert(schemer.valid?({ 'b' => nil }))
+    refute(schemer.valid?({ 'b' => 2.pow(64) }))
+    assert(schemer.valid?({ 'c' => 2.0 }))
+    assert(schemer.valid?({ 'c' => nil }))
+    refute(schemer.valid?({ 'c' => 2 }))
+    assert(schemer.valid?({ 'd' => 2.0 }))
+    assert(schemer.valid?({ 'd' => nil }))
+    refute(schemer.valid?({ 'd' => 2 }))
   end
 
   def test_openapi30_formats
     schema = {
       'properties' => {
-        'a' => { 'format' => 'int32' },
-        'b' => { 'format' => 'int64' },
-        'c' => { 'format' => 'float' },
-        'd' => { 'format' => 'double' },
+        'a' => { 'type' => 'integer', 'format' => 'int32' },
+        'b' => { 'type' => 'integer', 'format' => 'int64' },
+        'c' => { 'type' => 'number', 'format' => 'float' },
+        'd' => { 'type' => 'number', 'format' => 'double' },
         'e' => { 'format' => 'password' },
         'f' => { 'format' => 'byte' },
         'g' => { 'format' => 'binary' },
@@ -746,12 +777,16 @@ class OpenAPITest < Minitest::Test
     assert(schemer.valid_schema?)
     assert(schemer.valid?({ 'a' => 2.pow(31) }))
     refute(schemer.valid?({ 'a' => 2.pow(32) }))
+    refute(schemer.valid?({ 'a' => nil }))
     assert(schemer.valid?({ 'b' => 2.pow(63) }))
     refute(schemer.valid?({ 'b' => 2.pow(64) }))
+    refute(schemer.valid?({ 'b' => nil }))
     assert(schemer.valid?({ 'c' => 2.0 }))
     refute(schemer.valid?({ 'c' => 2 }))
+    refute(schemer.valid?({ 'c' => nil }))
     assert(schemer.valid?({ 'd' => 2.0 }))
     refute(schemer.valid?({ 'd' => 2 }))
+    refute(schemer.valid?({ 'd' => nil }))
     assert(schemer.valid?({ 'e' => 2 }))
     assert(schemer.valid?({ 'e' => 'anything' }))
     refute(schemer.valid?({ 'f' => '!' }))
@@ -762,6 +797,33 @@ class OpenAPITest < Minitest::Test
     assert(schemer.valid?({ 'h' => '2001-02-03' }))
     refute(schemer.valid?({ 'i' => '2001-02-03' }))
     assert(schemer.valid?({ 'i' => '2001-02-03T04:05:06.123456789+07:00' }))
+  end
+
+  def test_openapi30_nullable_formats
+    schema = {
+      'properties' => {
+        'a' => { 'type' => 'integer', 'format' => 'int32', 'nullable' => true },
+        'b' => { 'type' => 'integer', 'format' => 'int64', 'nullable' => true },
+        'c' => { 'type' => 'number', 'format' => 'float', 'nullable' => true },
+        'd' => { 'type' => 'number', 'format' => 'double', 'nullable' => true },
+      }
+    }
+
+    schemer = JSONSchemer.schema(schema, :meta_schema => JSONSchemer.openapi30)
+
+    assert(schemer.valid_schema?)
+    assert(schemer.valid?({ 'a' => 2.pow(31) }))
+    assert(schemer.valid?({ 'a' => nil }))
+    refute(schemer.valid?({ 'a' => 2.pow(32) }))
+    assert(schemer.valid?({ 'b' => 2.pow(63) }))
+    assert(schemer.valid?({ 'b' => nil }))
+    refute(schemer.valid?({ 'b' => 2.pow(64) }))
+    assert(schemer.valid?({ 'c' => 2.0 }))
+    assert(schemer.valid?({ 'c' => nil }))
+    refute(schemer.valid?({ 'c' => 2 }))
+    assert(schemer.valid?({ 'd' => 2.0 }))
+    assert(schemer.valid?({ 'd' => nil }))
+    refute(schemer.valid?({ 'd' => 2 }))
   end
 
   def test_unsupported_openapi_version

--- a/test/open_api_test.rb
+++ b/test/open_api_test.rb
@@ -778,8 +778,8 @@ class OpenAPITest < Minitest::Test
         'c' => { 'type' => 'number', 'format' => 'float' },
         'd' => { 'type' => 'number', 'format' => 'double' },
         'e' => { 'type' => 'string', 'format' => 'password' },
-        'f' => { 'format' => 'byte' },
-        'g' => { 'format' => 'binary' },
+        'f' => { 'type' => 'string', 'format' => 'byte' },
+        'g' => { 'type' => 'string', 'format' => 'binary' },
         'h' => { 'format' => 'date' },
         'i' => { 'format' => 'date-time' }
       }
@@ -804,10 +804,12 @@ class OpenAPITest < Minitest::Test
     refute(schemer.valid?({ 'd' => 2.to_s }))
     assert(schemer.valid?({ 'e' => 'anything' }))
     refute(schemer.valid?({ 'e' => 2 }))
-    refute(schemer.valid?({ 'f' => '!' }))
     assert(schemer.valid?({ 'f' => 'IQ==' }))
-    refute(schemer.valid?({ 'g' => '!' }))
+    refute(schemer.valid?({ 'f' => '!' }))
+    refute(schemer.valid?({ 'f' => 123 }))
     assert(schemer.valid?({ 'g' => '!'.b }))
+    refute(schemer.valid?({ 'g' => '!' }))
+    refute(schemer.valid?({ 'g' => 123 }))
     refute(schemer.valid?({ 'h' => '2001-02-03T04:05:06.123456789+07:00' }))
     assert(schemer.valid?({ 'h' => '2001-02-03' }))
     refute(schemer.valid?({ 'i' => '2001-02-03' }))
@@ -821,7 +823,9 @@ class OpenAPITest < Minitest::Test
         'b' => { 'type' => 'integer', 'format' => 'int64', 'nullable' => true },
         'c' => { 'type' => 'number', 'format' => 'float', 'nullable' => true },
         'd' => { 'type' => 'number', 'format' => 'double', 'nullable' => true },
-        'e' => { 'type' => 'string', 'format' => 'password', 'nullable' => true }
+        'e' => { 'type' => 'string', 'format' => 'password', 'nullable' => true },
+        'f' => { 'type' => 'string', 'format' => 'byte', 'nullable' => true },
+        'g' => { 'type' => 'string', 'format' => 'binary', 'nullable' => true }
       }
     }
 
@@ -843,6 +847,14 @@ class OpenAPITest < Minitest::Test
     assert(schemer.valid?({ 'e' => 'anything' }))
     assert(schemer.valid?({ 'e' => nil }))
     refute(schemer.valid?({ 'e' => 2 }))
+    assert(schemer.valid?({ 'f' => 'IQ==' }))
+    assert(schemer.valid?({ 'f' => nil }))
+    refute(schemer.valid?({ 'f' => '!' }))
+    refute(schemer.valid?({ 'f' => 123 }))
+    assert(schemer.valid?({ 'g' => '!'.b }))
+    assert(schemer.valid?({ 'g' => nil }))
+    refute(schemer.valid?({ 'g' => '!' }))
+    refute(schemer.valid?({ 'g' => 123 }))
   end
 
   def test_unsupported_openapi_version

--- a/test/open_api_test.rb
+++ b/test/open_api_test.rb
@@ -726,8 +726,10 @@ class OpenAPITest < Minitest::Test
     refute(schemer.valid?({ 'b' => 123.123 }))
     assert(schemer.valid?({ 'c' => 2.0 }))
     refute(schemer.valid?({ 'c' => 2 }))
+    refute(schemer.valid?({ 'c' => 2.to_s }))
     assert(schemer.valid?({ 'd' => 2.0 }))
     refute(schemer.valid?({ 'd' => 2 }))
+    refute(schemer.valid?({ 'd' => 2.to_s }))
     assert(schemer.valid?({ 'e' => 2 }))
     assert(schemer.valid?({ 'e' => 'anything' }))
   end
@@ -737,8 +739,8 @@ class OpenAPITest < Minitest::Test
       'properties' => {
         'a' => { 'type' => ['integer', 'boolean', 'null'], 'format' => 'int32' },
         'b' => { 'type' => ['integer', 'boolean', 'null'], 'format' => 'int64' },
-        'c' => { 'type' => ['number', 'null'], 'format' => 'float' },
-        'd' => { 'type' => ['number', 'null'], 'format' => 'double' }
+        'c' => { 'type' => ['number', 'boolean', 'null'], 'format' => 'float' },
+        'd' => { 'type' => ['number', 'boolean', 'null'], 'format' => 'double' }
       }
     }
 
@@ -754,9 +756,11 @@ class OpenAPITest < Minitest::Test
     assert(schemer.valid?({ 'b' => nil }))
     refute(schemer.valid?({ 'b' => 2.pow(64) }))
     assert(schemer.valid?({ 'c' => 2.0 }))
+    assert(schemer.valid?({ 'c' => true }))
     assert(schemer.valid?({ 'c' => nil }))
     refute(schemer.valid?({ 'c' => 2 }))
     assert(schemer.valid?({ 'd' => 2.0 }))
+    assert(schemer.valid?({ 'd' => true }))
     assert(schemer.valid?({ 'd' => nil }))
     refute(schemer.valid?({ 'd' => 2 }))
   end
@@ -789,10 +793,10 @@ class OpenAPITest < Minitest::Test
     refute(schemer.valid?({ 'b' => 123.123 }))
     assert(schemer.valid?({ 'c' => 2.0 }))
     refute(schemer.valid?({ 'c' => 2 }))
-    refute(schemer.valid?({ 'c' => nil }))
+    refute(schemer.valid?({ 'c' => 2.to_s }))
     assert(schemer.valid?({ 'd' => 2.0 }))
     refute(schemer.valid?({ 'd' => 2 }))
-    refute(schemer.valid?({ 'd' => nil }))
+    refute(schemer.valid?({ 'd' => 2.to_s }))
     assert(schemer.valid?({ 'e' => 2 }))
     assert(schemer.valid?({ 'e' => 'anything' }))
     refute(schemer.valid?({ 'f' => '!' }))

--- a/test/open_api_test.rb
+++ b/test/open_api_test.rb
@@ -707,7 +707,7 @@ class OpenAPITest < Minitest::Test
         'b' => { 'type' => 'integer', 'format' => 'int64' },
         'c' => { 'type' => 'number', 'format' => 'float' },
         'd' => { 'type' => 'number', 'format' => 'double' },
-        'e' => { 'format' => 'password' }
+        'e' => { 'type' => 'string', 'format' => 'password' }
       }
     }
 
@@ -730,8 +730,8 @@ class OpenAPITest < Minitest::Test
     assert(schemer.valid?({ 'd' => 2.0 }))
     refute(schemer.valid?({ 'd' => 2 }))
     refute(schemer.valid?({ 'd' => 2.to_s }))
-    assert(schemer.valid?({ 'e' => 2 }))
     assert(schemer.valid?({ 'e' => 'anything' }))
+    refute(schemer.valid?({ 'e' => 2 }))
   end
 
   def test_openapi31_formats_multiple_types
@@ -740,7 +740,8 @@ class OpenAPITest < Minitest::Test
         'a' => { 'type' => ['integer', 'boolean', 'null'], 'format' => 'int32' },
         'b' => { 'type' => ['integer', 'boolean', 'null'], 'format' => 'int64' },
         'c' => { 'type' => ['number', 'boolean', 'null'], 'format' => 'float' },
-        'd' => { 'type' => ['number', 'boolean', 'null'], 'format' => 'double' }
+        'd' => { 'type' => ['number', 'boolean', 'null'], 'format' => 'double' },
+        'e' => { 'type' => ['string', 'boolean', 'null'], 'format' => 'password' }
       }
     }
 
@@ -763,6 +764,10 @@ class OpenAPITest < Minitest::Test
     assert(schemer.valid?({ 'd' => true }))
     assert(schemer.valid?({ 'd' => nil }))
     refute(schemer.valid?({ 'd' => 2 }))
+    assert(schemer.valid?({ 'e' => 'anything' }))
+    assert(schemer.valid?({ 'e' => true }))
+    assert(schemer.valid?({ 'e' => nil }))
+    refute(schemer.valid?({ 'e' => 2 }))
   end
 
   def test_openapi30_formats
@@ -772,7 +777,7 @@ class OpenAPITest < Minitest::Test
         'b' => { 'type' => 'integer', 'format' => 'int64' },
         'c' => { 'type' => 'number', 'format' => 'float' },
         'd' => { 'type' => 'number', 'format' => 'double' },
-        'e' => { 'format' => 'password' },
+        'e' => { 'type' => 'string', 'format' => 'password' },
         'f' => { 'format' => 'byte' },
         'g' => { 'format' => 'binary' },
         'h' => { 'format' => 'date' },
@@ -797,8 +802,8 @@ class OpenAPITest < Minitest::Test
     assert(schemer.valid?({ 'd' => 2.0 }))
     refute(schemer.valid?({ 'd' => 2 }))
     refute(schemer.valid?({ 'd' => 2.to_s }))
-    assert(schemer.valid?({ 'e' => 2 }))
     assert(schemer.valid?({ 'e' => 'anything' }))
+    refute(schemer.valid?({ 'e' => 2 }))
     refute(schemer.valid?({ 'f' => '!' }))
     assert(schemer.valid?({ 'f' => 'IQ==' }))
     refute(schemer.valid?({ 'g' => '!' }))
@@ -815,7 +820,8 @@ class OpenAPITest < Minitest::Test
         'a' => { 'type' => 'integer', 'format' => 'int32', 'nullable' => true },
         'b' => { 'type' => 'integer', 'format' => 'int64', 'nullable' => true },
         'c' => { 'type' => 'number', 'format' => 'float', 'nullable' => true },
-        'd' => { 'type' => 'number', 'format' => 'double', 'nullable' => true }
+        'd' => { 'type' => 'number', 'format' => 'double', 'nullable' => true },
+        'e' => { 'type' => 'string', 'format' => 'password', 'nullable' => true }
       }
     }
 
@@ -834,6 +840,9 @@ class OpenAPITest < Minitest::Test
     assert(schemer.valid?({ 'd' => 2.0 }))
     assert(schemer.valid?({ 'd' => nil }))
     refute(schemer.valid?({ 'd' => 2 }))
+    assert(schemer.valid?({ 'e' => 'anything' }))
+    assert(schemer.valid?({ 'e' => nil }))
+    refute(schemer.valid?({ 'e' => 2 }))
   end
 
   def test_unsupported_openapi_version


### PR DESCRIPTION
I noticed some inconsistency in behaviour with how nullability works with the `format` keyword. Figured I'd put up a PR instead of just throwing it over the fence with an issue; you do enough hard work so thought I'd at least try to save you from some! 😆 

My assessment here may not be correct; I'm rather new-ish to Openapi and JSON Schema, so my understanding of the specification and expected behaviour might be wrong. Also not sure if my proposed solution here is the best path forward. My goal is more so to surface the problem I'm seeing - or at least what I _think_ is a problem. I won't be offended if you don't accept it 😆.

Anyways!

Let's say I have a schema to validate that a value is either a `date-time` string _or_ `null`. I can do so like this:

```ruby
date_schema =
  JSONSchemer.schema(
    { type: %w[string null], format: 'date-time' },
    meta_schema: 'https://spec.openapis.org/oas/3.1/dialect/base',
  )

date_schema.valid_schema? # true (just to confirm it's well formed)
date_schema.valid?('2025-01-20T21:34:48-05:00') # true
date_schema.valid?(nil) # true
```

Cool! _But_ if I try the same thing with `int32`:

```ruby
int32_schema =
  JSONSchemer.schema(
    { type: %w[integer null], format: 'int32' },
    meta_schema: 'https://spec.openapis.org/oas/3.1/dialect/base',
  )

int32_schema.valid_schema? # true (just to confirm it's well formed)
int32_schema.valid?(1) # true
int32_schema.valid?(nil) # false: "value at root does not match format: int32"
```

That same behaviour happens for `int32`, `int64`, `double`, and `float` (ie. the `format`s that Openapi add).

I compared the implementation of the Openapi formatters to the ones in the JSON schema 2020 draft and noticed that the JSON schema ones would simply return `true` if the input wasn't a `String`. This in effect meant that it would be `true` for a `nil` input. I thought that it might be appropriate to take a similar approach to the Openapi formatters and have them return `true` when the input is `nil` as well, which gets things working for the above example.

```ruby
int32_schema =
  JSONSchemer.schema(
    { type: %w[integer null], format: 'int32' },
    meta_schema: 'https://spec.openapis.org/oas/3.1/dialect/base',
  )

int32_schema.valid_schema? # true (just to confirm it's well formed)
int32_schema.valid?(1) # true
int32_schema.valid?(nil) # is now true!
```

Now, the tradeoff here is what happens when you _don't_ provide a `type` and _only_ provide a `format`.

```ruby
int32_schema =
  JSONSchemer.schema(
    { format: 'int32' },
    meta_schema: 'https://spec.openapis.org/oas/3.1/dialect/base',
  )

int32_schema.valid_schema? # true (just to confirm it's well formed)
int32_schema.valid?(1) # true
int32_schema.valid?(nil) # also true
```

This does seem awkward, but it is actually consistent with how the JSON schema formatters work.

```ruby
date_schema =
  JSONSchemer.schema(
    { format: 'date-time' },
    meta_schema: 'https://spec.openapis.org/oas/3.1/dialect/base',
  )
date_schema.valid_schema? # true (just to confirm it's well formed)
date_schema.valid?('2025-01-20T21:34:48-05:00') # true
date_schema.valid?(nil) # also true
```

To be honest, I don't know what the expected behaviour should be here. I promise I did my best to look through both Openapi and JSON schema specifications to get a better understanding of how nullable `format`s should work, but I wasn't able to find anything that cleared that up for me.

I admit that I may be overstepping my bounds here by making the formatters more lenient with `nil`. It doesn't _feel_ right, but since I observed that the same behaviour was happening with the JSON Schema formatters, I thought that maybe this was an appropriate solution.

It's worth noting that nullable formats _can_ be achieved by using `oneOf`

```ruby
int32_union_schema =
  JSONSchemer.schema(
    { oneOf: [{ type: 'integer', format: 'int32' }, { type: 'null' }] },
    meta_schema: 'https://spec.openapis.org/oas/3.1/dialect/base',
  )

int32_union_schema.valid_schema? # true (just to confirm it's well formed)
int32_union_schema.valid?(1) # true
int32_union_schema.valid?(nil) # true
```

so perhaps this is the correct way to specify a nullable format?
