### PR TITLE
Add value and details to i18n available interpolations

### DIFF
--- a/lib/json_schemer/result.rb
+++ b/lib/json_schemer/result.rb
@@ -81,7 +81,9 @@ module JSONSchemer
         :instance => instance,
         :instanceLocation => Location.resolve(instance_location),
         :keywordLocation => resolved_keyword_location,
-        :absoluteKeywordLocation => source.absolute_keyword_location
+        :absoluteKeywordLocation => source.absolute_keyword_location,
+        :value => source.value,
+        :details => details,
       )
     end
 

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -152,7 +152,7 @@ class ErrorsTest < Minitest::Test
       '#' => 'C',
       'https://json-schema.org/draft/2019-09/schema' => {
         '^' => 'F',
-        'type' => '6',
+        'type' => '6 %{value}',
         '*' => 'G/7'
       },
       '^' => 'H',
@@ -200,7 +200,7 @@ class ErrorsTest < Minitest::Test
     errors.fetch('https://example.com/schema').delete('*')
     i18n(errors) do
       assert_equal('F', schemer.validate(data, :output_format => 'basic').fetch('error'))
-      assert_equal('6', schemer.validate(data).first.fetch('error'))
+      assert_equal('6 string', schemer.validate(data).first.fetch('error'))
     end
 
     errors.fetch('https://json-schema.org/draft/2019-09/schema').delete('^')


### PR DESCRIPTION
The default errors include helpful information in the errors key.  For instance a Minimum validation like 

```json
"employee_count": {
        "type": "integer",
        "minimum": 1
}
```

 might include 

```json
"error": "number at /count is less than 1"`
```

In the `detailed` error return.  

Unfortunately - the values used to produce this string are not all available in the translation layer.

For keywords that produce error messages, the "default" error message is defined in the class itself - where it has access to the keywords `value` property and `details` passed into the `error` method.   Several of the default errors take advantage of these variables to expose richer error information.

In order to produce error messages of the same informativeness as the "default" message while taking advantage of the I18n layer - this PR exposes the `value` and `details` property of the keyword object that is already in scope when i18n is called - this allows us to for instance translate the above error in the PigLatin locale to:

```json
"error": "umbernay atyay /count isyay esslay anthay 1"
```

using i18n - rather than being limited to `umbernay atyay /count isyaya esslay anthay ethay inimumay`

