### PR TITLE
Apply discriminator before unevaluated keywords

### DIFF
--- a/lib/json_schemer.rb
+++ b/lib/json_schemer.rb
@@ -80,6 +80,7 @@ module JSONSchemer
   VOCABULARIES = {
     'https://json-schema.org/draft/2020-12/vocab/core' => Draft202012::Vocab::CORE,
     'https://json-schema.org/draft/2020-12/vocab/applicator' => Draft202012::Vocab::APPLICATOR,
+    'https://spec.openapis.org/oas/3.1/vocab/base' => OpenAPI31::Vocab::BASE,
     'https://json-schema.org/draft/2020-12/vocab/unevaluated' => Draft202012::Vocab::UNEVALUATED,
     'https://json-schema.org/draft/2020-12/vocab/validation' => Draft202012::Vocab::VALIDATION,
     'https://json-schema.org/draft/2020-12/vocab/format-annotation' => Draft202012::Vocab::FORMAT_ANNOTATION,
@@ -97,8 +98,6 @@ module JSONSchemer
     'json-schemer://draft7' => Draft7::Vocab::ALL,
     'json-schemer://draft6' => Draft6::Vocab::ALL,
     'json-schemer://draft4' => Draft4::Vocab::ALL,
-
-    'https://spec.openapis.org/oas/3.1/vocab/base' => OpenAPI31::Vocab::BASE,
     'json-schemer://openapi30' => OpenAPI30::Vocab::BASE
   }
   VOCABULARY_ORDER = VOCABULARIES.transform_values.with_index { |_vocabulary, index| index }


### PR DESCRIPTION
`discriminator` needs to run before `unevaluatedProperties` so that the correct list of unevaluated properties can be collected. From the [spec][0]:

> This means that "properties", "patternProperties", "additionalProperties", and all in-place applicators MUST be evaluated before this keyword can be evaluated.

`discriminator` is an "in-place applicator" in this case, because it replaces allOf/anyOf/oneOf.

Fixes: https://github.com/davishmcclurg/json_schemer/issues/217

[0]: https://json-schema.org/draft/2020-12/json-schema-core#section-11.3