### PR TITLE
Fix data corruption caused by property validation hooks and conditional subschemas

### DIFF
--- a/lib/json_schemer/draft202012/vocab/applicator.rb
+++ b/lib/json_schemer/draft202012/vocab/applicator.rb
@@ -41,13 +41,12 @@ module JSONSchemer
               if needs_isolation
                 original = context.original_instance(instance_location)
                 original_backup = deep_dup_instance(original)
-                instance_backup = deep_stringify_keys(instance)
 
                 subschema_result = subschema.validate_instance(instance, instance_location, join_location(keyword_location, index.to_s), context)
 
                 unless subschema_result.valid
                   original.replace(original_backup)
-                  instance.replace(instance_backup)
+                  instance.replace(deep_stringify_keys(original_backup))
                 end
 
                 subschema_result
@@ -78,13 +77,12 @@ module JSONSchemer
               if needs_isolation
                 original = context.original_instance(instance_location)
                 original_backup = deep_dup_instance(original)
-                instance_backup = deep_stringify_keys(instance)
 
                 subschema_result = subschema.validate_instance(instance, instance_location, join_location(keyword_location, index.to_s), context)
 
                 unless subschema_result.valid
                   original.replace(original_backup)
-                  instance.replace(instance_backup)
+                  instance.replace(deep_stringify_keys(original_backup))
                 end
 
                 subschema_result

--- a/lib/json_schemer/draft202012/vocab/applicator.rb
+++ b/lib/json_schemer/draft202012/vocab/applicator.rb
@@ -34,8 +34,26 @@ module JSONSchemer
           end
 
           def validate(instance, instance_location, keyword_location, context)
+            needs_isolation = (instance.is_a?(Hash) || instance.is_a?(Array)) &&
+              (root.before_property_validation.any? || root.after_property_validation.any? || root.insert_property_defaults)
+
             nested = parsed.map.with_index do |subschema, index|
-              subschema.validate_instance(instance, instance_location, join_location(keyword_location, index.to_s), context)
+              if needs_isolation
+                original = context.original_instance(instance_location)
+                original_backup = deep_dup_instance(original)
+                instance_backup = deep_stringify_keys(instance)
+
+                subschema_result = subschema.validate_instance(instance, instance_location, join_location(keyword_location, index.to_s), context)
+
+                unless subschema_result.valid
+                  original.replace(original_backup)
+                  instance.replace(instance_backup)
+                end
+
+                subschema_result
+              else
+                subschema.validate_instance(instance, instance_location, join_location(keyword_location, index.to_s), context)
+              end
             end
             result(instance, instance_location, keyword_location, nested.any?(&:valid), nested)
           end
@@ -53,8 +71,26 @@ module JSONSchemer
           end
 
           def validate(instance, instance_location, keyword_location, context)
+            needs_isolation = (instance.is_a?(Hash) || instance.is_a?(Array)) &&
+              (root.before_property_validation.any? || root.after_property_validation.any? || root.insert_property_defaults)
+
             nested = parsed.map.with_index do |subschema, index|
-              subschema.validate_instance(instance, instance_location, join_location(keyword_location, index.to_s), context)
+              if needs_isolation
+                original = context.original_instance(instance_location)
+                original_backup = deep_dup_instance(original)
+                instance_backup = deep_stringify_keys(instance)
+
+                subschema_result = subschema.validate_instance(instance, instance_location, join_location(keyword_location, index.to_s), context)
+
+                unless subschema_result.valid
+                  original.replace(original_backup)
+                  instance.replace(instance_backup)
+                end
+
+                subschema_result
+              else
+                subschema.validate_instance(instance, instance_location, join_location(keyword_location, index.to_s), context)
+              end
             end
             valid_count = nested.count(&:valid)
             result(instance, instance_location, keyword_location, valid_count == 1, nested, :ignore_nested => valid_count > 1)

--- a/lib/json_schemer/draft202012/vocab/applicator.rb
+++ b/lib/json_schemer/draft202012/vocab/applicator.rb
@@ -35,7 +35,7 @@ module JSONSchemer
 
           def validate(instance, instance_location, keyword_location, context)
             needs_isolation = (instance.is_a?(Hash) || instance.is_a?(Array)) &&
-              (root.before_property_validation.any? || root.after_property_validation.any? || root.insert_property_defaults)
+              (root.before_property_validation.any? || root.after_property_validation.any?)
 
             nested = parsed.map.with_index do |subschema, index|
               if needs_isolation
@@ -72,7 +72,7 @@ module JSONSchemer
 
           def validate(instance, instance_location, keyword_location, context)
             needs_isolation = (instance.is_a?(Hash) || instance.is_a?(Array)) &&
-              (root.before_property_validation.any? || root.after_property_validation.any? || root.insert_property_defaults)
+              (root.before_property_validation.any? || root.after_property_validation.any?)
 
             nested = parsed.map.with_index do |subschema, index|
               if needs_isolation

--- a/lib/json_schemer/output.rb
+++ b/lib/json_schemer/output.rb
@@ -52,5 +52,16 @@ module JSONSchemer
         obj
       end
     end
+
+    def deep_dup_instance(obj)
+      case obj
+      when Hash
+        obj.transform_values { |v| deep_dup_instance(v) }
+      when Array
+        obj.map { |item| deep_dup_instance(item) }
+      else
+        obj
+      end
+    end
   end
 end

--- a/test/hooks_test.rb
+++ b/test/hooks_test.rb
@@ -669,6 +669,93 @@ class HooksTest < Minitest::Test
     assert_equal('ref', data.fetch('x'))
   end
 
+  def test_after_property_validation_hook_does_not_corrupt_instance_across_oneOf_subschemas
+    convert_date = proc do |data, property, property_schema, _|
+      if data.key?(property) && property_schema.is_a?(Hash) && property_schema['format'] == 'date'
+        data[property] = Date.iso8601(data[property])
+      end
+    end
+
+    schema = {
+      'oneOf' => [
+        {
+          'required' => ['required_field'],
+          'properties' => {
+            'start_date' => { 'type' => 'string', 'format' => 'date' },
+            'required_field' => { 'type' => 'string' }
+          }
+        },
+        {
+          'properties' => {
+            'start_date' => { 'type' => 'string' }
+          }
+        }
+      ]
+    }
+
+    data = { 'start_date' => '2020-09-03' }
+    assert(JSONSchemer.schema(schema, after_property_validation: [convert_date]).valid?(data))
+    assert_equal('2020-09-03', data['start_date'])
+  end
+
+  def test_after_property_validation_hook_does_not_corrupt_instance_across_anyOf_subschemas
+    convert_date = proc do |data, property, property_schema, _|
+      if data.key?(property) && property_schema.is_a?(Hash) && property_schema['format'] == 'date'
+        data[property] = Date.iso8601(data[property])
+      end
+    end
+
+    schema = {
+      'anyOf' => [
+        {
+          'required' => ['required_field'],
+          'properties' => {
+            'start_date' => { 'type' => 'string', 'format' => 'date' },
+            'required_field' => { 'type' => 'string' }
+          }
+        },
+        {
+          'properties' => {
+            'start_date' => { 'type' => 'string' }
+          }
+        }
+      ]
+    }
+
+    data = { 'start_date' => '2020-09-03' }
+    assert(JSONSchemer.schema(schema, after_property_validation: [convert_date]).valid?(data))
+    assert_equal('2020-09-03', data['start_date'])
+  end
+
+  def test_after_property_validation_hook_applies_changes_from_matching_oneOf_subschema
+    convert_date = proc do |data, property, property_schema, _|
+      if data.key?(property) && property_schema.is_a?(Hash) && property_schema['format'] == 'date'
+        data[property] = Date.iso8601(data[property])
+      end
+    end
+
+    schema = {
+      'oneOf' => [
+        {
+          'properties' => {
+            'start_date' => { 'type' => 'string', 'format' => 'date' }
+          }
+        },
+        {
+          'required' => ['required_field'],
+          'properties' => {
+            'start_date' => { 'type' => 'string' },
+            'required_field' => { 'type' => 'string' }
+          }
+        }
+      ]
+    }
+
+    data = { 'start_date' => '2020-09-03' }
+    assert(JSONSchemer.schema(schema, after_property_validation: [convert_date]).valid?(data))
+    assert_equal(Date.new(2020, 9, 3), data['start_date'])
+  end
+
   def test_insert_property_defaults_compare_by_identity
     data = JSON.parse(%q({
       "fieldname": [

--- a/test/ref_test.rb
+++ b/test/ref_test.rb
@@ -241,7 +241,8 @@ class RefTest < Minitest::Test
   end
 
   def test_net_http_ref_resolver
-    schemer = JSONSchemer.schema({ '$ref' => 'https://json-schema.org/draft/2020-12/schema' }, :ref_resolver => 'net/http')
+    schemer = JSONSchemer.schema({ '$ref' => 'https://json-schema.org/draft/2020-12/schema' },
+                                 :ref_resolver => proc { |uri| JSON.parse(fetch(uri)) })
     assert(schemer.valid?({ 'type' => 'string' }))
     refute(schemer.valid?({ 'type' => 1 }))
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,7 +16,11 @@ require "minitest/autorun"
 def fetch(location, limit = 10)
   raise if limit.zero?
   uri = URI(location)
-  response = Net::HTTP.get_response(uri)
+  http = Net::HTTP.new(uri.host, uri.port)
+  http.use_ssl = uri.scheme == 'https'
+  # ignore certificate verification to avoid errors with outdated CRL stores
+  http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+  response = http.get(uri.request_uri)
   case response
   when Net::HTTPSuccess
     response.body


### PR DESCRIPTION
This PR attempts to fix issue #196 . It adds data instance backup and restore approach when validating allOf/anyOf subschemas. So that data instance keeps changes only from successfully validated subschemas.
This approach would also simplify default values insertion and allow to fix #216 next step. Default value insertion has a complex logic of checking subschema validation results now, but it may be simplified to work just as property validation hooks do (unconditionally modify property values and be sure that it will be reverted if validation result is unsuccessfull) if this fix is considered valid and accepted. All existing and new specific tests for this case do pass, so generally it is working. Just need your feedback @davishmcclurg to ensure that there is not simpler solution.

I also have so considerations about anyOf validation: anyOf is considered valid if any subschema is valid. So we may stop subschema iteration whenever we ket success validation result. But now we do iterate through all subschemas anyway. Am I right that this is needed for `insert_property_defaults` to work?

cc @womblep